### PR TITLE
WIP: Implement balance-fetching for derivable descriptors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - cargo check --verbose --no-default-features --features=minimal,debug-calls
   - cargo check --verbose --no-default-features --features=proxy,use-openssl
   - cargo check --verbose --no-default-features --features=proxy,use-rustls
+  - cargo check --verbose --features=aggregation
 
 before_cache:
   - rm -rf "$TRAVIS_HOME/.cargo/registry/src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ openssl = { version = "^0.10", optional = true }
 rustls = { version = "0.16.0", optional = true, features = ["dangerous_configuration"] }
 webpki = { version = "0.21.0", optional = true }
 webpki-roots = { version = "^0.19", optional = true }
+miniscript = { version = "4", optional = true}
+# Hack to activate global context feature, keep version in sync with rust-bitcoin
+secp256k1 = { version = "0.19.0", features = ["global-context", "rand-std"], optional = true }
 
 [features]
 default = ["proxy", "use-rustls"]
@@ -36,3 +39,4 @@ debug-calls = []
 proxy = ["socks"]
 use-rustls = ["webpki", "webpki-roots", "rustls"]
 use-openssl = ["openssl"]
+aggregation = ["miniscript", "secp256k1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod config;
 pub mod raw_client;
 mod stream;
 mod types;
+mod util;
 
 pub use api::ElectrumApi;
 pub use batch::Batch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 pub extern crate bitcoin;
 extern crate core;
 extern crate log;
+#[cfg(feature = "aggregation")]
+extern crate miniscript;
 #[cfg(feature = "use-openssl")]
 extern crate openssl;
 #[cfg(all(
@@ -62,3 +64,7 @@ pub use batch::Batch;
 pub use client::*;
 pub use config::{ConfigBuilder, Socks5Config};
 pub use types::*;
+
+/// Miniscript wallet descriptor
+#[cfg(feature = "aggregation")]
+pub type Descriptor = miniscript::Descriptor<miniscript::descriptor::DescriptorPublicKey>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,51 @@
+pub trait Itertools: Sized + Iterator {
+    fn chunk(self, len: usize) -> ChunkIter<Self> {
+        ChunkIter {
+            inner: self,
+            chunk_size: len,
+        }
+    }
+}
+impl<I: Iterator + Sized> Itertools for I {}
+
+pub struct ChunkIter<I>
+where
+    I: Iterator + Sized,
+{
+    inner: I,
+    chunk_size: usize,
+}
+
+impl<I: Iterator> Iterator for ChunkIter<I> {
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let take_it = &mut self.inner;
+        let chunk: Self::Item = take_it.take(self.chunk_size).collect();
+        if chunk.is_empty() {
+            None
+        } else {
+            Some(chunk)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use util::Itertools;
+
+    #[test]
+    fn chunk_iter() {
+        assert_eq!((0..128).into_iter().chunk(64).count(), 2);
+        assert_eq!((0..128).into_iter().chunk(2).count(), 64);
+        assert_eq!((0..0).into_iter().chunk(2).count(), 0);
+        assert_eq!((0..1).into_iter().chunk(2).count(), 1);
+        assert_eq!((0..2).into_iter().chunk(2).count(), 1);
+        assert_eq!((0..3).into_iter().chunk(2).count(), 2);
+
+        assert_eq!(
+            (0..3).into_iter().chunk(2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2]]
+        );
+    }
+}


### PR DESCRIPTION
This PR adds balance fetching based on miniscript descriptors and extended public keys. In its current form external and internal chains have to be fetched separately and added afterwards, which I think is reasonable.

This PR depends on rust-bitcoin/rust-miniscript#116, the following things have to happen for it to become merge ready:

- [ ] a new release of rust-bitcoin including rust-bitcoin/rust-bitcoin#443 has to be released
- [ ] rust-bitcoin/rust-miniscript#116 has to be finalized and depend on the newly release rust-bitcoin version
- [ ] a new version of rust-miniscript has to be released
- [ ] this PR has to be updated to depend on the new rust-bitcoin and rust-miniscript versions
