### PR TITLE
Config

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,0 +1,39 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+
+  test-fmt:
+    name: Test
+    runs-on: ubuntu-20.04
+    env:
+      TEST_ELECTRUM_SERVER: electrum.blockstream.info:50001
+      #TEST_ELECTRUM_SERVER: bitcoin.aranguren.org:50001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install rustup
+        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Set default toolchain
+        run: $HOME/.cargo/bin/rustup default stable
+      - name: Set profile
+        run: $HOME/.cargo/bin/rustup set profile minimal
+      - name: Fmt
+        run: cargo fmt -- --check --verbose
+      - name: Test
+        run: cargo test --verbose --all
+      - run: cargo check --verbose --features=use-openssl
+      - run: cargo check --verbose --no-default-features --features=proxy
+      - run: cargo check --verbose --no-default-features --features=minimal
+      - run: cargo check --verbose --no-default-features --features=minimal,debug-calls
+      - run: cargo check --verbose --no-default-features --features=proxy,use-openssl
+      - run: cargo check --verbose --no-default-features --features=proxy,use-rustls

--- a/examples/plaintext.rs
+++ b/examples/plaintext.rs
@@ -3,7 +3,7 @@ extern crate electrum_client;
 use electrum_client::{Client, ElectrumApi};
 
 fn main() {
-    let client = Client::new("tcp://electrum.blockstream.info:50001", None).unwrap();
+    let client = Client::new("tcp://electrum.blockstream.info:50001").unwrap();
     let res = client.server_features();
     println!("{:#?}", res);
 }

--- a/examples/ssl.rs
+++ b/examples/ssl.rs
@@ -3,7 +3,7 @@ extern crate electrum_client;
 use electrum_client::{Client, ElectrumApi};
 
 fn main() {
-    let client = Client::new("ssl://electrum.blockstream.info:50002", None).unwrap();
+    let client = Client::new("ssl://electrum.blockstream.info:50002").unwrap();
     let res = client.server_features();
     println!("{:#?}", res);
 }

--- a/examples/tor.rs
+++ b/examples/tor.rs
@@ -1,19 +1,21 @@
 extern crate electrum_client;
 
-use electrum_client::{Client, ElectrumApi};
+use electrum_client::{Client, ConfigBuilder, ElectrumApi, Socks5Config};
 
 fn main() {
     // NOTE: This assumes Tor is running localy, with an unauthenticated Socks5 listening at
     // localhost:9050
+    let proxy = Socks5Config::new("127.0.0.1:9050");
+    let config = ConfigBuilder::new().socks5(Some(proxy)).unwrap().build();
 
-    let client = Client::new("tcp://explorernuoc63nb.onion:110", Some("127.0.0.1:9050")).unwrap();
+    let client = Client::from_config("tcp://explorernuoc63nb.onion:110", config.clone()).unwrap();
     let res = client.server_features();
     println!("{:#?}", res);
 
     // works both with onion v2/v3 (if your Tor supports them)
-    let client = Client::new(
+    let client = Client::from_config(
         "tcp://explorerzydxu5ecjrkwceayqybizmpjjznk5izmitf2modhcusuqlid.onion:110",
-        Some("127.0.0.1:9050"),
+        config,
     )
     .unwrap();
     let res = client.server_features();

--- a/src/api.rs
+++ b/src/api.rs
@@ -38,7 +38,7 @@ pub trait ElectrumApi {
     /// Takes a list of `txids` and returns a list of transactions.
     fn batch_transaction_get<'t, I>(&self, txids: I) -> Result<Vec<Transaction>, Error>
     where
-        I: IntoIterator<Item = &'t Txid>,
+        I: IntoIterator<Item = &'t Txid> + Clone,
     {
         self.batch_transaction_get_raw(txids)?
             .iter()
@@ -49,9 +49,9 @@ pub trait ElectrumApi {
     /// Batch version of [`block_header`](#method.block_header).
     ///
     /// Takes a list of `heights` of blocks and returns a list of headers.
-    fn batch_block_header<'s, I>(&self, heights: I) -> Result<Vec<BlockHeader>, Error>
+    fn batch_block_header<I>(&self, heights: I) -> Result<Vec<BlockHeader>, Error>
     where
-        I: IntoIterator<Item = u32>,
+        I: IntoIterator<Item = u32> + Clone,
     {
         self.batch_block_header_raw(heights)?
             .iter()
@@ -68,7 +68,7 @@ pub trait ElectrumApi {
     /// Execute a queue of calls stored in a [`Batch`](../batch/struct.Batch.html) struct. Returns
     /// `Ok()` **only if** all of the calls are successful. The order of the JSON `Value`s returned
     /// reflects the order in which the calls were made on the `Batch` struct.
-    fn batch_call(&self, batch: Batch) -> Result<Vec<serde_json::Value>, Error>;
+    fn batch_call(&self, batch: &Batch) -> Result<Vec<serde_json::Value>, Error>;
 
     /// Subscribes to notifications for new block headers, by sending a `blockchain.headers.subscribe` call and
     /// returns the current tip as raw bytes instead of deserializing them.
@@ -118,7 +118,7 @@ pub trait ElectrumApi {
     /// Takes a list of scripts and returns a list of balance responses.
     fn batch_script_get_balance<'s, I>(&self, scripts: I) -> Result<Vec<GetBalanceRes>, Error>
     where
-        I: IntoIterator<Item = &'s Script>;
+        I: IntoIterator<Item = &'s Script> + Clone;
 
     /// Returns the history for a *scriptPubKey*
     fn script_get_history(&self, script: &Script) -> Result<Vec<GetHistoryRes>, Error>;
@@ -128,7 +128,7 @@ pub trait ElectrumApi {
     /// Takes a list of scripts and returns a list of history responses.
     fn batch_script_get_history<'s, I>(&self, scripts: I) -> Result<Vec<Vec<GetHistoryRes>>, Error>
     where
-        I: IntoIterator<Item = &'s Script>;
+        I: IntoIterator<Item = &'s Script> + Clone;
 
     /// Returns the list of unspent outputs for a *scriptPubKey*
     fn script_list_unspent(&self, script: &Script) -> Result<Vec<ListUnspentRes>, Error>;
@@ -141,7 +141,7 @@ pub trait ElectrumApi {
         scripts: I,
     ) -> Result<Vec<Vec<ListUnspentRes>>, Error>
     where
-        I: IntoIterator<Item = &'s Script>;
+        I: IntoIterator<Item = &'s Script> + Clone;
 
     /// Gets the raw bytes of a transaction with `txid`. Returns an error if not found.
     fn transaction_get_raw(&self, txid: &Txid) -> Result<Vec<u8>, Error>;
@@ -151,22 +151,22 @@ pub trait ElectrumApi {
     /// Takes a list of `txids` and returns a list of transactions raw bytes.
     fn batch_transaction_get_raw<'t, I>(&self, txids: I) -> Result<Vec<Vec<u8>>, Error>
     where
-        I: IntoIterator<Item = &'t Txid>;
+        I: IntoIterator<Item = &'t Txid> + Clone;
 
     /// Batch version of [`block_header_raw`](#method.block_header_raw).
     ///
     /// Takes a list of `heights` of blocks and returns a list of block header raw bytes.
-    fn batch_block_header_raw<'s, I>(&self, heights: I) -> Result<Vec<Vec<u8>>, Error>
+    fn batch_block_header_raw<I>(&self, heights: I) -> Result<Vec<Vec<u8>>, Error>
     where
-        I: IntoIterator<Item = u32>;
+        I: IntoIterator<Item = u32> + Clone;
 
     /// Batch version of [`estimate_fee`](#method.estimate_fee).
     ///
     /// Takes a list of `numbers` of blocks and returns a list of fee required in
     /// **Satoshis per kilobyte** to confirm a transaction in the given number of blocks.
-    fn batch_estimate_fee<'s, I>(&self, numbers: I) -> Result<Vec<f64>, Error>
+    fn batch_estimate_fee<I>(&self, numbers: I) -> Result<Vec<f64>, Error>
     where
-        I: IntoIterator<Item = usize>;
+        I: IntoIterator<Item = usize> + Clone;
 
     /// Broadcasts the raw bytes of a transaction to the network.
     fn transaction_broadcast_raw(&self, raw_tx: &[u8]) -> Result<Txid, Error>;

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -63,6 +63,14 @@ impl Batch {
         self.calls
             .push((String::from("blockchain.block.header"), params));
     }
+
+    /// Returns an iterator on the batch
+    pub fn iter(&self) -> BatchIter {
+        BatchIter {
+            batch: self,
+            index: 0,
+        }
+    }
 }
 
 impl std::iter::IntoIterator for Batch {
@@ -71,6 +79,21 @@ impl std::iter::IntoIterator for Batch {
 
     fn into_iter(self) -> Self::IntoIter {
         self.calls.into_iter()
+    }
+}
+
+pub struct BatchIter<'a> {
+    batch: &'a Batch,
+    index: usize,
+}
+
+impl<'a> std::iter::Iterator for BatchIter<'a> {
+    type Item = &'a (String, Vec<Param>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let val = self.batch.calls.get(self.index);
+        self.index += 1;
+        val
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -111,7 +111,7 @@ impl ClientType {
 }
 
 impl Client {
-    /// Default constructor supporting multiple backend by providing a prefix
+    /// Default constructor supporting multiple backends by providing a prefix
     ///
     /// Supported prefixes are:
     /// - tcp:// for a TCP plaintext client.

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,7 +63,7 @@ macro_rules! impl_inner_call {
                     // previous loop when trying to read()
                     if let Ok(mut write_client) = $self.client_type.try_write() {
                         loop {
-                            std::thread::sleep(std::time::Duration::from_secs(errors.len() as u64));
+                            std::thread::sleep(std::time::Duration::from_secs((1 << errors.len()).min(30) as u64));
                             match ClientType::from_config(&$self.url, &$self.config) {
                                 Ok(new_client) => {
                                     info!("Succesfully created new client");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,130 @@
+use crate::Error;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Proxy socks5 configuration, default None
+    socks5: Option<Socks5Config>,
+    /// timeout in seconds, default None (depends on TcpStream default)
+    timeout: Option<Duration>,
+    /// number of retry if any error, default 1
+    retry: u8,
+    /// when ssl, validate the domain, default true
+    validate_domain: bool,
+}
+
+/// Configuration for Socks5
+#[derive(Debug, Clone)]
+pub struct Socks5Config {
+    /// The address of the socks5 service
+    pub addr: String,
+    /// Optional credential for the service
+    pub credentials: Option<Socks5Credential>,
+}
+
+/// Credential for the proxy
+#[derive(Debug, Clone)]
+pub struct Socks5Credential {
+    pub username: String,
+    pub password: String,
+}
+
+/// [Config] Builder
+pub struct ConfigBuilder {
+    config: Config,
+}
+
+impl ConfigBuilder {
+    /// Create a builder with a default config, equivalent to [ConfigBuilder::default()]
+    pub fn new() -> Self {
+        ConfigBuilder {
+            config: Config::default(),
+        }
+    }
+
+    /// Set the socks5 config if Some, it accept an `Option` because it's easier for the caller to use
+    /// in a method chain
+    pub fn socks5(mut self, socks5_config: Option<Socks5Config>) -> Result<Self, Error> {
+        if socks5_config.is_some() && self.config.timeout.is_some() {
+            return Err(Error::BothSocksAndTimeout);
+        }
+        self.config.socks5 = socks5_config;
+        Ok(self)
+    }
+
+    /// Sets the timeout
+    pub fn timeout(mut self, timeout: u8) -> Result<Self, Error> {
+        if self.config.socks5.is_some() {
+            return Err(Error::BothSocksAndTimeout);
+        }
+        self.config.timeout = Some(Duration::from_secs(timeout as u64));
+        Ok(self)
+    }
+
+    /// Sets the retry attempts number
+    pub fn retry(mut self, retry: u8) -> Self {
+        self.config.retry = retry;
+        self
+    }
+
+    /// Sets if the domain has to be validated
+    pub fn validate_domain(mut self, validate_domain: bool) -> Self {
+        self.config.validate_domain = validate_domain;
+        self
+    }
+
+    /// Return the config and consume the builder
+    pub fn build(self) -> Config {
+        self.config
+    }
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Socks5Config {
+    /// Socks5Config constructor without credentials
+    pub fn new(addr: impl ToString) -> Self {
+        let addr = addr.to_string().replacen("socks5://", "", 1);
+        Socks5Config {
+            addr,
+            credentials: None,
+        }
+    }
+
+    /// Socks5Config constructor if we have credentials
+    pub fn with_credentials(addr: impl ToString, username: String, password: String) -> Self {
+        let mut config = Socks5Config::new(addr);
+        config.credentials = Some(Socks5Credential { username, password });
+        config
+    }
+}
+
+impl Config {
+    pub fn socks5(&self) -> &Option<Socks5Config> {
+        &self.socks5
+    }
+    pub fn retry(&self) -> u8 {
+        self.retry
+    }
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+    pub fn validate_domain(&self) -> bool {
+        self.validate_domain
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            socks5: None,
+            timeout: None,
+            retry: 1,
+            validate_domain: true,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ```no_run
 //! use electrum_client::{Client, ElectrumApi};
 //!
-//! let mut client = Client::new("tcp://electrum.blockstream.info:50001", None)?;
+//! let mut client = Client::new("tcp://electrum.blockstream.info:50001")?;
 //! let response = client.server_features()?;
 //! # Ok::<(), electrum_client::Error>(())
 //! ```
@@ -47,6 +47,8 @@ mod batch;
 ))]
 pub mod client;
 
+mod config;
+
 pub mod raw_client;
 mod stream;
 mod types;
@@ -58,4 +60,5 @@ pub use batch::Batch;
     all(feature = "proxy", feature = "use-rustls")
 ))]
 pub use client::*;
+pub use config::{ConfigBuilder, Socks5Config};
 pub use types::*;

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -404,6 +404,7 @@ impl<S: Read + Write> RawClient<S> {
                             s.send(ChannelMessage::Error(error.clone()))
                                 .expect("Unable to send ChannelMessage::Error");
                         }
+                        return Err(Error::SharedIOError(error.clone()));
                     }
                     trace!("<== {}", raw_resp);
 
@@ -535,7 +536,7 @@ impl<S: Read + Write> RawClient<S> {
                         Ok(ChannelMessage::Error(e)) => {
                             warn!("Received ChannelMessage::Error");
 
-                            break Err(Error::ChannelError(e));
+                            break Err(Error::SharedIOError(e));
                         }
                         e @ Err(_) => e.map(|_| ()).expect("Error receiving from channel"), // panic if there's something wrong with the channels
                     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -288,6 +288,14 @@ pub enum Error {
     MissingDomain,
     /// SSL over a socks5 proxy is currently not supported
     SSLOverSocks5,
+    /// Made one or multiple attempts, always in Error
+    AllAttemptsErrored(Vec<Error>),
+    /// There was an error transmitted from the reader thread to others
+    ChannelError,
+    /// Setting both a proxy and a timeout in `Config` results in this error
+    BothSocksAndTimeout,
+    /// Setting both a timeout and passing zero or more than one socket addrs is an error
+    WrongAddrsNumberWithTimeout,
 
     /// Couldn't take a lock on the reader mutex. This means that there's already another reader
     /// thread running

--- a/src/types.rs
+++ b/src/types.rs
@@ -291,8 +291,8 @@ pub enum Error {
     SSLOverSocks5,
     /// Made one or multiple attempts, always in Error
     AllAttemptsErrored(Vec<Error>),
-    /// There was an error transmitted from the reader thread to others
-    ChannelError(Arc<std::io::Error>),
+    /// There was an io error reading the socket, to be shared between threads
+    SharedIOError(Arc<std::io::Error>),
     /// Setting both a proxy and a timeout in `Config` results in this error
     BothSocksAndTimeout,
     /// Setting both a timeout and passing zero or more than one socket addrs is an error

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@
 
 use std::convert::TryFrom;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use bitcoin::blockdata::block;
 use bitcoin::consensus::encode::deserialize;
@@ -291,7 +292,7 @@ pub enum Error {
     /// Made one or multiple attempts, always in Error
     AllAttemptsErrored(Vec<Error>),
     /// There was an error transmitted from the reader thread to others
-    ChannelError,
+    ChannelError(Arc<std::io::Error>),
     /// Setting both a proxy and a timeout in `Config` results in this error
     BothSocksAndTimeout,
     /// Setting both a timeout and passing zero or more than one socket addrs is an error


### PR DESCRIPTION
## Implements retry, timeout, socks credential and others fixes
    
Retry works by checking if an non-protocol error happened during the call, if so an attempt to take a write lock on the client is made and a new client attempted
    if both operationare succesfull the old_client is substituted with the new one.
    
Timeout is a single parameter for connect,read and write TCP timeouts, special handling is required for the following situation: cannot set a timeout with a proxy and cannot set timeout with multipl SocketAddrs
    
Since configurations parameter grow, a Config struct with a builder has been introduced
    
Some new errors variant has been introduced
    
Errors in reading input in the reader thread now warns other eventual threads with ChannelMessage::Error

Add github actions equivalent to travis cause travis is slow



