### PR TITLE
Fixing calls_made fn signature

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -183,5 +183,5 @@ pub trait ElectrumApi {
 
     #[cfg(feature = "debug-calls")]
     /// Returns the number of network calls made since the creation of the client.
-    fn calls_made(&self) -> usize;
+    fn calls_made(&self) -> Result<usize, Error>;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -285,7 +285,7 @@ impl ElectrumApi for Client {
 
     #[inline]
     #[cfg(feature = "debug-calls")]
-    fn calls_made(&self) -> usize {
+    fn calls_made(&self) -> Result<usize, Error> {
         impl_inner_call!(self, calls_made)
     }
 }

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -984,8 +984,8 @@ impl<T: Read + Write> ElectrumApi for RawClient<T> {
     }
 
     #[cfg(feature = "debug-calls")]
-    fn calls_made(&self) -> usize {
-        self.calls.load(Ordering::SeqCst)
+    fn calls_made(&self) -> Result<usize, Error> {
+        Ok(self.calls.load(Ordering::SeqCst))
     }
 }
 


### PR DESCRIPTION
Currently compilation with `--all-features` and `--feature debug-calls` or `cargo test` is broken. This PR fixes it