### PR TITLE
Getting rid of lock().unwrap()

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
 
@@ -8,7 +9,10 @@ impl<T: Read + Write> Read for ClonableStream<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0
             .lock()
-            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .map_err(|_| {
+                error!("Unable to acquire lock on ClonableStream read operation");
+                io::Error::from(io::ErrorKind::BrokenPipe)
+            })?
             .read(buf)
     }
 }
@@ -17,14 +21,20 @@ impl<T: Read + Write> Write for ClonableStream<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0
             .lock()
-            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .map_err(|_| {
+                error!("Unable to acquire lock on ClonableStream write operation");
+                io::Error::from(io::ErrorKind::BrokenPipe)
+            })?
             .write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         self.0
             .lock()
-            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .map_err(|_| {
+                error!("Unable to acquire lock on ClonableStream flush operation");
+                io::Error::from(io::ErrorKind::BrokenPipe)
+            })?
             .flush()
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,17 +6,26 @@ pub struct ClonableStream<T: Read + Write>(Arc<Mutex<T>>);
 
 impl<T: Read + Write> Read for ClonableStream<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().read(buf)
+        self.0
+            .lock()
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .read(buf)
     }
 }
 
 impl<T: Read + Write> Write for ClonableStream<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
+        self.0
+            .lock()
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.0.lock().unwrap().flush()
+        self.0
+            .lock()
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?
+            .flush()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -344,6 +344,7 @@ impl Display for Error {
             Error::MissingDomain => f.write_str("Missing domain while it was explicitly asked to validate it"),
             Error::BothSocksAndTimeout => f.write_str("Setting both a proxy and a timeout in `Config` is an error"),
             Error::CouldntLockReader => f.write_str("Couldn't take a lock on the reader mutex. This means that there's already another reader thread is running"),
+            Error::Mpsc => f.write_str("Broken IPC communication channel: the other thread probably has exited"),
         }
     }
 }
@@ -367,7 +368,7 @@ impl_error!(bitcoin::consensus::encode::Error, Bitcoin);
 
 impl<T> From<std::sync::PoisonError<T>> for Error {
     fn from(_: std::sync::PoisonError<T>) -> Self {
-        Error::CouldntLockReader
+        Error::IOError(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,7 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::{Script, Txid};
 
 use serde::{de, Deserialize, Serialize};
+use std::sync::PoisonError;
 
 static JSONRPC_2_0: &str = "2.0";
 
@@ -362,3 +363,9 @@ impl_error!(std::io::Error, IOError);
 impl_error!(serde_json::Error, JSON);
 impl_error!(bitcoin::hashes::hex::Error, Hex);
 impl_error!(bitcoin::consensus::encode::Error, Bitcoin);
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(_: PoisonError<T>) -> Self {
+        Error::CouldntLockReader
+    }
+}


### PR DESCRIPTION
PR removes 16 (!) `unwraps()` which are unnecessary and were already covered by an error case.

This is quite important for the overall library stability