### PR TITLE
Fix CI testing for all features

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Fmt
         run: cargo fmt -- --check --verbose
       - name: Test
-        run: cargo test --verbose --all
+        run: cargo test --verbose --all-features
       - run: cargo check --verbose --features=use-openssl
       - run: cargo check --verbose --no-default-features --features=proxy
       - run: cargo check --verbose --no-default-features --features=minimal


### PR DESCRIPTION
`cargo test --all` is a deprecated equivalent of `cargo test --workspace`. This leads to the fact that tests are run without using all features (utilizing default set of features only) and such bugs as #32 missed by CI.