### PR TITLE
Rework retry logic within `impl_inner_call`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -77,11 +77,16 @@ macro_rules! impl_inner_call {
                                     break;
                                 },
                                 Err(e) => {
-                                    warn!("client retry:{}/{} {:?}", errors.len() + 1, $self.config.retry(), e);
-                                    errors.push(e);
-                                    if errors.len() as u8 == $self.config.retry() {
+                                    let failed_attempts = errors.len() + 1;
+
+                                    if retries_exhausted(failed_attempts, $self.config.retry()) {
+                                        warn!("re-creating client failed after {} attempts", failed_attempts);
                                         return Err(Error::AllAttemptsErrored(errors));
                                     }
+
+                                    warn!("re-creating client failed with {}, retry: {}/{}", e, failed_attempts, $self.config.retry());
+
+                                    errors.push(e);
                                 }
                             }
                         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -54,7 +54,7 @@ macro_rules! impl_inner_call {
                 Err(e) => {
                     warn!("call retry:{}/{} {:?}", errors.len() + 1 , $self.config.retry(), e);
                     errors.push(e);
-                    if errors.len() as u8 == $self.config.retry() {
+                    if errors.len() as u8 > $self.config.retry() {
                         return Err(Error::AllAttemptsErrored(errors));
                     }
 


### PR DESCRIPTION
The first patch fixes #47 by properly comparing the number of failed attempts with the value of config.retry.

The second patch improves the logging that happens as part of this logic.