### PR TITLE
Make `unconfirmed` an `i64`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -208,7 +208,9 @@ pub struct GetBalanceRes {
     /// Confirmed balance in Satoshis for the address.
     pub confirmed: u64,
     /// Unconfirmed balance in Satoshis for the address.
-    pub unconfirmed: u64,
+    ///
+    /// Some servers (e.g. `electrs`) return this as a negative value.
+    pub unconfirmed: i64,
 }
 
 /// Response to a [`transaction_get_merkle`](../client/struct.Client.html#method.transaction_get_merkle) request.


### PR DESCRIPTION
Some servers like electrs return the unconfirmed balance for an address as a
negative value.

Closes #45