### PR TITLE
Enable TCP support without socks5 or SSL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::Error;
 use std::time::Duration;
 
+/// [Client] configuration options.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// Proxy socks5 configuration, default None
@@ -104,15 +105,22 @@ impl Socks5Config {
 }
 
 impl Config {
+    /// Get the socks5 config option.
     pub fn socks5(&self) -> &Option<Socks5Config> {
         &self.socks5
     }
+
+    /// Get the retry config option.
     pub fn retry(&self) -> u8 {
         self.retry
     }
+
+    /// Get the timeout config option.
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
+
+    /// Get the validate_domain config option.
     pub fn validate_domain(&self) -> bool {
         self.validate_domain
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,6 @@ extern crate webpki_roots;
 mod api;
 mod batch;
 
-#[cfg(any(
-    all(feature = "proxy", feature = "use-openssl"),
-    all(feature = "proxy", feature = "use-rustls")
-))]
 pub mod client;
 
 mod config;
@@ -55,10 +51,8 @@ mod types;
 
 pub use api::ElectrumApi;
 pub use batch::Batch;
-#[cfg(any(
-    all(feature = "proxy", feature = "use-openssl"),
-    all(feature = "proxy", feature = "use-rustls")
-))]
 pub use client::*;
-pub use config::{Config, ConfigBuilder, Socks5Config};
+#[cfg(feature = "proxy")]
+pub use config::Socks5Config;
+pub use config::{Config, ConfigBuilder};
 pub use types::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -302,6 +302,8 @@ pub enum Error {
     CouldntLockReader,
     /// Broken IPC communication channel: the other thread probably has exited
     Mpsc,
+    /// SSL support requires feature `use-openssl` or `use-rustls`.
+    SslSupportNotConfigured,
 
     #[cfg(feature = "use-openssl")]
     /// Invalid OpenSSL method used
@@ -345,6 +347,7 @@ impl Display for Error {
             Error::BothSocksAndTimeout => f.write_str("Setting both a proxy and a timeout in `Config` is an error"),
             Error::CouldntLockReader => f.write_str("Couldn't take a lock on the reader mutex. This means that there's already another reader thread is running"),
             Error::Mpsc => f.write_str("Broken IPC communication channel: the other thread probably has exited"),
+            Error::SslSupportNotConfigured => f.write_str("SSL support not configured, requires feature `use-openssl` or `use-rustls`"),
         }
     }
 }


### PR DESCRIPTION
Currently users of the library must configure SSL or a socks5 proxy even if they only want a plain TCP stream. This is contrary to the comment in `lib.rs` that suggests `features=minimal` may be used to get TCP only (will not currently build with `--no-default-features`).

There is no need to force plaintext TCP stream users to enable SSL and/or proxy features.

Enable `Client` to be used for plaintext TCP stream without requiring any of the features `use-openssl`, `use-rustls`, or `proxy`.

- Patch 1 clears a few clippy warnings by adding trivial docs (I'm not 100% sure the link (`[Config]`) works.
- Patch 2 implements the actual PR as describe above.

Note: All the conditional compilation is pretty ugly IMO. I use additional braces that are not strictly required by rustc but seem to make the code easier to read (also my editor messes with the syntax highlighting without them, bad form I know doing code changes to assist the editor).
