### PR TITLE
bump rust-bitcoin to v0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "^0.4"
-bitcoin = { version = "0.26", features = ["use-serde"] }
+bitcoin = { version = "^0.27", features = ["use-serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 


### PR DESCRIPTION
Simply updating `rust-bitcoin` dependency to latest