### PR TITLE
Support getting verbose transactions

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -33,6 +33,9 @@ pub trait ElectrumApi {
         Ok(deserialize(&self.transaction_get_raw(txid)?)?)
     }
 
+    /// Gets the verbose transaction with `txid`. Returns an error if not found.
+    fn transaction_get_verbose(&self, txid: &Txid) -> Result<GetTransactionVerboseRes, Error>;
+
     /// Batch version of [`transaction_get`](#method.transaction_get).
     ///
     /// Takes a list of `txids` and returns a list of transactions.

--- a/src/client.rs
+++ b/src/client.rs
@@ -253,6 +253,11 @@ impl ElectrumApi for Client {
     }
 
     #[inline]
+    fn transaction_get_verbose(&self, txid: &Txid) -> Result<GetTransactionVerboseRes, Error> {
+        impl_inner_call!(self, transaction_get_verbose, txid)
+    }
+
+    #[inline]
     fn transaction_get_raw(&self, txid: &Txid) -> Result<Vec<u8>, Error> {
         impl_inner_call!(self, transaction_get_raw, txid)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains definitions of all the complex data structures that are returned by calls
 
+use bitcoin::BlockHash;
 use std::convert::TryFrom;
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
@@ -211,6 +212,40 @@ pub struct GetBalanceRes {
     ///
     /// Some servers (e.g. `electrs`) return this as a negative value.
     pub unconfirmed: i64,
+}
+
+// TODO: Implement transaction serialization for inputs and outputs, for
+// example with pub vin: Vec<TxIn> and pub vout: Vec<TxOut>
+
+/// Response to a [`transaction_get`](../client/struct.Client.html#method.transaction_get) request
+/// with the verbose true flag set
+#[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GetTransactionVerboseRes {
+    /// Block hash of the block containing the transaction.
+    #[serde(default)]
+    pub blockhash: Option<BlockHash>,
+    /// Block time of the block containing the transaction.
+    #[serde(default)]
+    pub blocktime: Option<u32>,
+    /// Confirmations of the transaction
+    #[serde(default)]
+    pub confirmations: Option<u32>,
+    /// Same as blocktime
+    #[serde(default)]
+    pub time: Option<u32>,
+    /// The transaction hash (differs from txid for witness transactions)
+    pub hash: Txid,
+    /// The serialized, hex-encoded data for 'txid'
+    pub hex: String,
+    /// nLocktime of the transaction
+    pub locktime: u32,
+    /// Size of the serialized transaction
+    pub size: usize,
+    /// Id of the transaction
+    pub txid: Txid,
+    /// Version of the transaction
+    pub version: i32,
 }
 
 /// Response to a [`transaction_get_merkle`](../client/struct.Client.html#method.transaction_get_merkle) request.


### PR DESCRIPTION
This allows the caller to get extra information of a transaction, like the block hash of the block its included in and the number of
confirmations.

Some electrum servers do not support this method, which is reflected in the test of the method.