### PR TITLE
Add `Config::builder` method

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,10 @@ impl Config {
     pub fn validate_domain(&self) -> bool {
         self.validate_domain
     }
+
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+    }
 }
 
 impl Default for Config {


### PR DESCRIPTION
The intention is to reduce some confusion on how to manipulate `Config`.
The alternative is to make `Config` fields public.