### PR TITLE
Update build badge to use GitHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# rust-electrum-client [![Build Status]][travis] [![Latest Version]][crates.io]
+# rust-electrum-client [![Build Status]][GitHub Workflow] [![Latest Version]][crates.io]
 
-[Build Status]: https://api.travis-ci.org/MagicalBitcoin/rust-electrum-client.svg?branch=master
-[travis]: https://travis-ci.org/MagicalBitcoin/rust-electrum-client
+[Build Status]: https://github.com/bitcoindevkit/rust-electrum-client/actions/workflows/cont_integration.yml/badge.svg
+[GitHub Workflow]: https://github.com/bitcoindevkit/rust-electrum-client/actions?query=workflow%3ACI
 [Latest Version]: https://img.shields.io/crates/v/electrum-client.svg
 [crates.io]: https://crates.io/crates/electrum-client
-
 
 Bitcoin Electrum client library. Supports plaintext, TLS and Onion servers.


### PR DESCRIPTION
The current build badge using Travis is not working anymore.
This PR uses the badge from GitHub instead.