### PR TITLE
Add raw_call to ElectrumApi

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -65,6 +65,9 @@ pub trait ElectrumApi {
         self.transaction_broadcast_raw(&buffer)
     }
 
+    /// Executes the requested API call returning the raw answer.
+    fn raw_call(&self, call: &Call) -> Result<serde_json::Value, Error>;
+
     /// Execute a queue of calls stored in a [`Batch`](../batch/struct.Batch.html) struct. Returns
     /// `Ok()` **only if** all of the calls are successful. The order of the JSON `Value`s returned
     /// reflects the order in which the calls were made on the `Batch` struct.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -5,7 +5,7 @@
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::{Script, Txid};
 
-use types::{Param, ToElectrumScriptHash};
+use types::{Call, Param, ToElectrumScriptHash};
 
 /// Helper structure that caches all the requests before they are actually sent to the server.
 ///
@@ -18,7 +18,7 @@ use types::{Param, ToElectrumScriptHash};
 /// [`batch_script_get_balance`](../client/struct.Client.html#method.batch_script_get_balance) to ask the
 /// server for the balance of multiple scripts with a single request.
 pub struct Batch {
-    calls: Vec<(String, Vec<Param>)>,
+    calls: Vec<Call>,
 }
 
 impl Batch {

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,6 +161,11 @@ impl Client {
 
 impl ElectrumApi for Client {
     #[inline]
+    fn raw_call(&self, call: &Call) -> Result<serde_json::Value, Error> {
+        impl_inner_call!(self, raw_call, call)
+    }
+
+    #[inline]
     fn batch_call(&self, batch: &Batch) -> Result<Vec<serde_json::Value>, Error> {
         impl_inner_call!(self, batch_call, batch)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,8 @@ use serde::{de, Deserialize, Serialize};
 
 static JSONRPC_2_0: &str = "2.0";
 
+pub type Call = (String, Vec<Param>);
+
 #[derive(Serialize, Clone)]
 #[serde(untagged)]
 /// A single parameter of a [`Request`](struct.Request.html)


### PR DESCRIPTION
In order to give more flexibility to the users of this library I added a `raw_call` method to the `ElectrumApi` trait that will allow to call any arbitrary electrum API call.