### PR TITLE
Implement timeout for socks connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,23 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 
 # Optional dependencies
-socks = { version = "0.3", optional = true }
 openssl = { version = "0.10", optional = true }
 rustls = { version = "0.20", optional = true, features = ["dangerous_configuration"] }
 webpki = { version = "0.22", optional = true }
 webpki-roots = { version = "0.22", optional = true }
 
+byteorder = { version = "1.0", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version="0.3.9", features=["winsock2"], optional = true }
+
 [features]
 default = ["proxy", "use-rustls"]
 minimal = []
 debug-calls = []
-proxy = ["socks"]
+proxy = ["byteorder", "winapi", "libc"]
 use-rustls = ["webpki", "webpki-roots", "rustls"]
 use-openssl = ["openssl"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -111,9 +111,12 @@ impl ClientType {
         if url.starts_with("ssl://") {
             let url = url.replacen("ssl://", "", 1);
             let client = match config.socks5() {
-                Some(socks5) => {
-                    RawClient::new_proxy_ssl(url.as_str(), config.validate_domain(), socks5)?
-                }
+                Some(socks5) => RawClient::new_proxy_ssl(
+                    url.as_str(),
+                    config.validate_domain(),
+                    socks5,
+                    config.timeout(),
+                )?,
                 None => {
                     RawClient::new_ssl(url.as_str(), config.validate_domain(), config.timeout())?
                 }
@@ -125,7 +128,11 @@ impl ClientType {
 
             Ok(match config.socks5().as_ref() {
                 None => ClientType::TCP(RawClient::new(url.as_str(), config.timeout())?),
-                Some(socks5) => ClientType::Socks5(RawClient::new_proxy(url.as_str(), socks5)?),
+                Some(socks5) => ClientType::Socks5(RawClient::new_proxy(
+                    url.as_str(),
+                    socks5,
+                    config.timeout(),
+                )?),
             })
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,18 +45,12 @@ impl ConfigBuilder {
     /// Set the socks5 config if Some, it accept an `Option` because it's easier for the caller to use
     /// in a method chain
     pub fn socks5(mut self, socks5_config: Option<Socks5Config>) -> Result<Self, Error> {
-        if socks5_config.is_some() && self.config.timeout.is_some() {
-            return Err(Error::BothSocksAndTimeout);
-        }
         self.config.socks5 = socks5_config;
         Ok(self)
     }
 
     /// Sets the timeout
     pub fn timeout(mut self, timeout: Option<u8>) -> Result<Self, Error> {
-        if timeout.is_some() && self.config.socks5.is_some() {
-            return Err(Error::BothSocksAndTimeout);
-        }
         self.config.timeout = timeout.map(|t| Duration::from_secs(t as u64));
         Ok(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,22 @@ extern crate openssl;
 extern crate rustls;
 extern crate serde;
 extern crate serde_json;
-#[cfg(any(feature = "default", feature = "proxy"))]
-extern crate socks;
+
 #[cfg(any(feature = "use-rustls", feature = "default"))]
 extern crate webpki;
 #[cfg(any(feature = "use-rustls", feature = "default"))]
 extern crate webpki_roots;
+
+#[cfg(any(feature = "default", feature = "proxy"))]
+extern crate byteorder;
+
+#[cfg(all(unix, any(feature = "default", feature = "proxy")))]
+extern crate libc;
+#[cfg(all(windows, any(feature = "default", feature = "proxy")))]
+extern crate winapi;
+
+#[cfg(any(feature = "default", feature = "proxy"))]
+mod socks;
 
 mod api;
 mod batch;

--- a/src/socks/mod.rs
+++ b/src/socks/mod.rs
@@ -1,0 +1,162 @@
+//! SOCKS proxy clients
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+use std::vec;
+
+pub use self::v4::{Socks4Listener, Socks4Stream};
+pub use self::v5::{Socks5Datagram, Socks5Listener, Socks5Stream};
+
+mod v4;
+mod v5;
+mod writev;
+
+/// A description of a connection target.
+#[derive(Debug, Clone)]
+pub enum TargetAddr {
+    /// Connect to an IP address.
+    Ip(SocketAddr),
+    /// Connect to a fully qualified domain name.
+    ///
+    /// The domain name will be passed along to the proxy server and DNS lookup
+    /// will happen there.
+    Domain(String, u16),
+}
+
+impl ToSocketAddrs for TargetAddr {
+    type Iter = Iter;
+
+    fn to_socket_addrs(&self) -> io::Result<Iter> {
+        let inner = match *self {
+            TargetAddr::Ip(addr) => IterInner::Ip(Some(addr)),
+            TargetAddr::Domain(ref domain, port) => {
+                let it = (&**domain, port).to_socket_addrs()?;
+                IterInner::Domain(it)
+            }
+        };
+        Ok(Iter(inner))
+    }
+}
+
+enum IterInner {
+    Ip(Option<SocketAddr>),
+    Domain(vec::IntoIter<SocketAddr>),
+}
+
+/// An iterator over `SocketAddr`s associated with a `TargetAddr`.
+pub struct Iter(IterInner);
+
+impl Iterator for Iter {
+    type Item = SocketAddr;
+
+    fn next(&mut self) -> Option<SocketAddr> {
+        match self.0 {
+            IterInner::Ip(ref mut addr) => addr.take(),
+            IterInner::Domain(ref mut it) => it.next(),
+        }
+    }
+}
+
+/// A trait for objects that can be converted to `TargetAddr`.
+pub trait ToTargetAddr {
+    /// Converts the value of `self` to a `TargetAddr`.
+    fn to_target_addr(&self) -> io::Result<TargetAddr>;
+}
+
+impl ToTargetAddr for TargetAddr {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        Ok(self.clone())
+    }
+}
+
+impl ToTargetAddr for SocketAddr {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        Ok(TargetAddr::Ip(*self))
+    }
+}
+
+impl ToTargetAddr for SocketAddrV4 {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        SocketAddr::V4(*self).to_target_addr()
+    }
+}
+
+impl ToTargetAddr for SocketAddrV6 {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        SocketAddr::V6(*self).to_target_addr()
+    }
+}
+
+impl ToTargetAddr for (Ipv4Addr, u16) {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        SocketAddrV4::new(self.0, self.1).to_target_addr()
+    }
+}
+
+impl ToTargetAddr for (Ipv6Addr, u16) {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        SocketAddrV6::new(self.0, self.1, 0, 0).to_target_addr()
+    }
+}
+
+impl<'a> ToTargetAddr for (&'a str, u16) {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        // try to parse as an IP first
+        if let Ok(addr) = self.0.parse::<Ipv4Addr>() {
+            return (addr, self.1).to_target_addr();
+        }
+
+        if let Ok(addr) = self.0.parse::<Ipv6Addr>() {
+            return (addr, self.1).to_target_addr();
+        }
+
+        Ok(TargetAddr::Domain(self.0.to_owned(), self.1))
+    }
+}
+
+impl<'a> ToTargetAddr for &'a str {
+    fn to_target_addr(&self) -> io::Result<TargetAddr> {
+        // try to parse as an IP first
+        if let Ok(addr) = self.parse::<SocketAddrV4>() {
+            return addr.to_target_addr();
+        }
+
+        if let Ok(addr) = self.parse::<SocketAddrV6>() {
+            return addr.to_target_addr();
+        }
+
+        // split the string by ':' and convert the second part to u16
+        let mut parts_iter = self.rsplitn(2, ':');
+        let port_str = match parts_iter.next() {
+            Some(s) => s,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "invalid socket address",
+                ))
+            }
+        };
+
+        let host = match parts_iter.next() {
+            Some(s) => s,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "invalid socket address",
+                ))
+            }
+        };
+
+        let port: u16 = match port_str.parse() {
+            Ok(p) => p,
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "invalid port value",
+                ))
+            }
+        };
+
+        (host, port).to_target_addr()
+    }
+}

--- a/src/socks/v4.rs
+++ b/src/socks/v4.rs
@@ -1,0 +1,288 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{self, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6, TcpStream, ToSocketAddrs};
+
+use super::{TargetAddr, ToTargetAddr};
+
+fn read_response(socket: &mut TcpStream) -> io::Result<SocketAddrV4> {
+    let mut response = [0u8; 8];
+    socket.read_exact(&mut response)?;
+    let mut response = &response[..];
+
+    if response.read_u8()? != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid response version",
+        ));
+    }
+
+    match response.read_u8()? {
+        90 => {}
+        91 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "request rejected or failed",
+            ))
+        }
+        92 => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "request rejected because SOCKS server cannot connect to \
+                                       idnetd on the client",
+            ))
+        }
+        93 => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "request rejected because the client program and identd \
+                                       report different user-ids",
+            ))
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid response code",
+            ))
+        }
+    }
+
+    let port = response.read_u16::<BigEndian>()?;
+    let ip = Ipv4Addr::from(response.read_u32::<BigEndian>()?);
+
+    Ok(SocketAddrV4::new(ip, port))
+}
+
+/// A SOCKS4 client.
+#[derive(Debug)]
+pub struct Socks4Stream {
+    socket: TcpStream,
+    proxy_addr: SocketAddrV4,
+}
+
+impl Socks4Stream {
+    /// Connects to a target server through a SOCKS4 proxy.
+    ///
+    /// # Note
+    ///
+    /// If `target` is a `TargetAddr::Domain`, the domain name will be forwarded
+    /// to the proxy server using the SOCKS4A protocol extension. If the proxy
+    /// server does not support SOCKS4A, consider performing the DNS lookup
+    /// locally and passing a `TargetAddr::Ip`.
+    pub fn connect<T, U>(proxy: T, target: U, userid: &str) -> io::Result<Socks4Stream>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        Self::connect_raw(1, proxy, target, userid)
+    }
+
+    fn connect_raw<T, U>(command: u8, proxy: T, target: U, userid: &str) -> io::Result<Socks4Stream>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        let mut socket = TcpStream::connect(proxy)?;
+
+        let target = target.to_target_addr()?;
+
+        let mut packet = vec![];
+        let _ = packet.write_u8(4); // version
+        let _ = packet.write_u8(command); // command code
+        match target.to_target_addr()? {
+            TargetAddr::Ip(addr) => {
+                let addr = match addr {
+                    SocketAddr::V4(addr) => addr,
+                    SocketAddr::V6(_) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "SOCKS4 does not support IPv6",
+                        ));
+                    }
+                };
+                let _ = packet.write_u16::<BigEndian>(addr.port());
+                let _ = packet.write_u32::<BigEndian>((*addr.ip()).into());
+                let _ = packet.write_all(userid.as_bytes());
+                let _ = packet.write_u8(0);
+            }
+            TargetAddr::Domain(ref host, port) => {
+                let _ = packet.write_u16::<BigEndian>(port);
+                let _ = packet.write_u32::<BigEndian>(Ipv4Addr::new(0, 0, 0, 1).into());
+                let _ = packet.write_all(userid.as_bytes());
+                let _ = packet.write_u8(0);
+                let _ = packet.extend(host.as_bytes());
+                let _ = packet.write_u8(0);
+            }
+        }
+
+        socket.write_all(&packet)?;
+        let proxy_addr = read_response(&mut socket)?;
+
+        Ok(Socks4Stream {
+            socket: socket,
+            proxy_addr: proxy_addr,
+        })
+    }
+
+    /// Returns the proxy-side address of the connection between the proxy and
+    /// target server.
+    pub fn proxy_addr(&self) -> SocketAddrV4 {
+        self.proxy_addr
+    }
+
+    /// Returns a shared reference to the inner `TcpStream`.
+    pub fn get_ref(&self) -> &TcpStream {
+        &self.socket
+    }
+
+    /// Returns a mutable reference to the inner `TcpStream`.
+    pub fn get_mut(&mut self) -> &mut TcpStream {
+        &mut self.socket
+    }
+
+    /// Consumes the `Socks4Stream`, returning the inner `TcpStream`.
+    pub fn into_inner(self) -> TcpStream {
+        self.socket
+    }
+}
+
+impl Read for Socks4Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.socket.read(buf)
+    }
+}
+
+impl<'a> Read for &'a Socks4Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&self.socket).read(buf)
+    }
+}
+
+impl Write for Socks4Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.socket.flush()
+    }
+}
+
+impl<'a> Write for &'a Socks4Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (&self.socket).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (&self.socket).flush()
+    }
+}
+
+/// A SOCKS4 BIND client.
+#[derive(Debug)]
+pub struct Socks4Listener(Socks4Stream);
+
+impl Socks4Listener {
+    /// Initiates a BIND request to the specified proxy.
+    ///
+    /// The proxy will filter incoming connections based on the value of
+    /// `target`.
+    pub fn bind<T, U>(proxy: T, target: U, userid: &str) -> io::Result<Socks4Listener>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        Socks4Stream::connect_raw(2, proxy, target, userid).map(Socks4Listener)
+    }
+
+    /// The address of the proxy-side TCP listener.
+    ///
+    /// This should be forwarded to the remote process, which should open a
+    /// connection to it.
+    pub fn proxy_addr(&self) -> io::Result<SocketAddr> {
+        if self.0.proxy_addr.ip().octets() != [0, 0, 0, 0] {
+            Ok(SocketAddr::V4(self.0.proxy_addr()))
+        } else {
+            let port = self.0.proxy_addr.port();
+            let peer = match self.0.socket.peer_addr()? {
+                SocketAddr::V4(addr) => SocketAddr::V4(SocketAddrV4::new(*addr.ip(), port)),
+                SocketAddr::V6(addr) => SocketAddr::V6(SocketAddrV6::new(*addr.ip(), port, 0, 0)),
+            };
+            Ok(peer)
+        }
+    }
+
+    /// Waits for the remote process to connect to the proxy server.
+    ///
+    /// The value of `proxy_addr` should be forwarded to the remote process
+    /// before this method is called.
+    pub fn accept(mut self) -> io::Result<Socks4Stream> {
+        self.0.proxy_addr = read_response(&mut self.0.socket)?;
+        Ok(self.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::{Read, Write};
+    use std::net::{SocketAddr, SocketAddrV4, TcpStream, ToSocketAddrs};
+
+    use super::*;
+
+    fn google_ip() -> SocketAddrV4 {
+        "google.com:80"
+            .to_socket_addrs()
+            .unwrap()
+            .filter_map(|a| match a {
+                SocketAddr::V4(a) => Some(a),
+                SocketAddr::V6(_) => None,
+            })
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    #[ignore]
+    fn google() {
+        let mut socket = Socks4Stream::connect("127.0.0.1:1080", google_ip(), "").unwrap();
+
+        socket.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+        let mut result = vec![];
+        socket.read_to_end(&mut result).unwrap();
+
+        println!("{}", String::from_utf8_lossy(&result));
+        assert!(result.starts_with(b"HTTP/1.0"));
+        assert!(result.ends_with(b"</HTML>\r\n") || result.ends_with(b"</html>"));
+    }
+
+    #[test]
+    #[ignore] // dante doesn't support SOCKS4A
+    fn google_dns() {
+        let mut socket = Socks4Stream::connect("127.0.0.1:8080", "google.com:80", "").unwrap();
+
+        socket.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+        let mut result = vec![];
+        socket.read_to_end(&mut result).unwrap();
+
+        println!("{}", String::from_utf8_lossy(&result));
+        assert!(result.starts_with(b"HTTP/1.0"));
+        assert!(result.ends_with(b"</HTML>\r\n") || result.ends_with(b"</html>"));
+    }
+
+    #[test]
+    #[ignore]
+    fn bind() {
+        // First figure out our local address that we'll be connecting from
+        let socket = Socks4Stream::connect("127.0.0.1:1080", google_ip(), "").unwrap();
+        let addr = socket.proxy_addr();
+
+        let listener = Socks4Listener::bind("127.0.0.1:1080", addr, "").unwrap();
+        let addr = listener.proxy_addr().unwrap();
+        let mut end = TcpStream::connect(addr).unwrap();
+        let mut conn = listener.accept().unwrap();
+        conn.write_all(b"hello world").unwrap();
+        drop(conn);
+        let mut result = vec![];
+        end.read_to_end(&mut result).unwrap();
+        assert_eq!(result, b"hello world");
+    }
+}

--- a/src/socks/v5.rs
+++ b/src/socks/v5.rs
@@ -1,0 +1,836 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::cmp;
+use std::io::{self, Read, Write};
+use std::net::{
+    Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, TcpStream, ToSocketAddrs, UdpSocket,
+};
+use std::ptr;
+use std::time::Duration;
+
+use super::writev::WritevExt;
+use super::{TargetAddr, ToTargetAddr};
+
+const MAX_ADDR_LEN: usize = 260;
+
+fn read_addr<R: Read>(socket: &mut R) -> io::Result<TargetAddr> {
+    match socket.read_u8()? {
+        1 => {
+            let ip = Ipv4Addr::from(socket.read_u32::<BigEndian>()?);
+            let port = socket.read_u16::<BigEndian>()?;
+            Ok(TargetAddr::Ip(SocketAddr::V4(SocketAddrV4::new(ip, port))))
+        }
+        3 => {
+            let len = socket.read_u8()?;
+            let mut domain = vec![0; len as usize];
+            socket.read_exact(&mut domain)?;
+            let domain = String::from_utf8(domain)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let port = socket.read_u16::<BigEndian>()?;
+            Ok(TargetAddr::Domain(domain, port))
+        }
+        4 => {
+            let mut ip = [0; 16];
+            socket.read_exact(&mut ip)?;
+            let ip = Ipv6Addr::from(ip);
+            let port = socket.read_u16::<BigEndian>()?;
+            Ok(TargetAddr::Ip(SocketAddr::V6(SocketAddrV6::new(
+                ip, port, 0, 0,
+            ))))
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "unsupported address type",
+        )),
+    }
+}
+
+fn read_response(socket: &mut TcpStream) -> io::Result<TargetAddr> {
+    if socket.read_u8()? != 5 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid response version",
+        ));
+    }
+
+    match socket.read_u8()? {
+        0 => {}
+        1 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "general SOCKS server failure",
+            ))
+        }
+        2 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "connection not allowed by ruleset",
+            ))
+        }
+        3 => return Err(io::Error::new(io::ErrorKind::Other, "network unreachable")),
+        4 => return Err(io::Error::new(io::ErrorKind::Other, "host unreachable")),
+        5 => return Err(io::Error::new(io::ErrorKind::Other, "connection refused")),
+        6 => return Err(io::Error::new(io::ErrorKind::Other, "TTL expired")),
+        7 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "command not supported",
+            ))
+        }
+        8 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "address kind not supported",
+            ))
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::Other, "unknown error")),
+    }
+
+    if socket.read_u8()? != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid reserved byte",
+        ));
+    }
+
+    read_addr(socket)
+}
+
+fn write_addr(mut packet: &mut [u8], target: &TargetAddr) -> io::Result<usize> {
+    let start_len = packet.len();
+    match *target {
+        TargetAddr::Ip(SocketAddr::V4(addr)) => {
+            packet.write_u8(1).unwrap();
+            packet.write_u32::<BigEndian>((*addr.ip()).into()).unwrap();
+            packet.write_u16::<BigEndian>(addr.port()).unwrap();
+        }
+        TargetAddr::Ip(SocketAddr::V6(addr)) => {
+            packet.write_u8(4).unwrap();
+            packet.write_all(&addr.ip().octets()).unwrap();
+            packet.write_u16::<BigEndian>(addr.port()).unwrap();
+        }
+        TargetAddr::Domain(ref domain, port) => {
+            packet.write_u8(3).unwrap();
+            if domain.len() > u8::max_value() as usize {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "domain name too long",
+                ));
+            }
+            packet.write_u8(domain.len() as u8).unwrap();
+            packet.write_all(domain.as_bytes()).unwrap();
+            packet.write_u16::<BigEndian>(port).unwrap();
+        }
+    }
+
+    Ok(start_len - packet.len())
+}
+
+/// Authentication methods
+#[derive(Debug)]
+enum Authentication<'a> {
+    Password {
+        username: &'a str,
+        password: &'a str,
+    },
+    None,
+}
+
+impl<'a> Authentication<'a> {
+    fn id(&self) -> u8 {
+        match *self {
+            Authentication::Password { .. } => 2,
+            Authentication::None => 0,
+        }
+    }
+
+    fn is_no_auth(&self) -> bool {
+        if let Authentication::None = *self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// A SOCKS5 client.
+#[derive(Debug)]
+pub struct Socks5Stream {
+    socket: TcpStream,
+    proxy_addr: TargetAddr,
+}
+
+impl Socks5Stream {
+    /// Connects to a target server through a SOCKS5 proxy.
+    pub fn connect<T, U>(proxy: T, target: U, timeout: Option<Duration>) -> io::Result<Socks5Stream>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        Self::connect_raw(1, proxy, target, &Authentication::None, timeout)
+    }
+
+    /// Connects to a target server through a SOCKS5 proxy using given
+    /// username and password.
+    pub fn connect_with_password<T, U>(
+        proxy: T,
+        target: U,
+        username: &str,
+        password: &str,
+        timeout: Option<Duration>,
+    ) -> io::Result<Socks5Stream>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        let auth = Authentication::Password { username, password };
+        Self::connect_raw(1, proxy, target, &auth, timeout)
+    }
+
+    fn connect_raw<T, U>(
+        command: u8,
+        proxy: T,
+        target: U,
+        auth: &Authentication,
+        timeout: Option<Duration>,
+    ) -> io::Result<Socks5Stream>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        let mut socket = if let Some(timeout) = timeout {
+            let addr = proxy.to_socket_addrs().unwrap().next().unwrap();
+            TcpStream::connect_timeout(&addr, timeout)?
+        } else {
+            TcpStream::connect(proxy)?
+        };
+
+        let target = target.to_target_addr()?;
+
+        let packet_len = if auth.is_no_auth() { 3 } else { 4 };
+        let packet = [
+            5,                                     // protocol version
+            if auth.is_no_auth() { 1 } else { 2 }, // method count
+            auth.id(),                             // method
+            0,                                     // no auth (always offered)
+        ];
+        socket.write_all(&packet[..packet_len])?;
+
+        let mut buf = [0; 2];
+        socket.read_exact(&mut buf)?;
+        let response_version = buf[0];
+        let selected_method = buf[1];
+
+        if response_version != 5 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid response version",
+            ));
+        }
+
+        if selected_method == 0xff {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "no acceptable auth methods",
+            ));
+        }
+
+        if selected_method != auth.id() && selected_method != Authentication::None.id() {
+            return Err(io::Error::new(io::ErrorKind::Other, "unknown auth method"));
+        }
+
+        match *auth {
+            Authentication::Password { username, password } if selected_method == auth.id() => {
+                Self::password_authentication(&mut socket, username, password)?
+            }
+            _ => (),
+        }
+
+        let mut packet = [0; MAX_ADDR_LEN + 3];
+        packet[0] = 5; // protocol version
+        packet[1] = command; // command
+        packet[2] = 0; // reserved
+        let len = write_addr(&mut packet[3..], &target)?;
+        socket.write_all(&packet[..len + 3])?;
+
+        let proxy_addr = read_response(&mut socket)?;
+
+        Ok(Socks5Stream {
+            socket: socket,
+            proxy_addr: proxy_addr,
+        })
+    }
+
+    fn password_authentication(
+        socket: &mut TcpStream,
+        username: &str,
+        password: &str,
+    ) -> io::Result<()> {
+        if username.len() < 1 || username.len() > 255 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid username",
+            ));
+        };
+        if password.len() < 1 || password.len() > 255 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid password",
+            ));
+        }
+
+        let mut packet = [0; 515];
+        let packet_size = 3 + username.len() + password.len();
+        packet[0] = 1; // version
+        packet[1] = username.len() as u8;
+        packet[2..2 + username.len()].copy_from_slice(username.as_bytes());
+        packet[2 + username.len()] = password.len() as u8;
+        packet[3 + username.len()..packet_size].copy_from_slice(password.as_bytes());
+        socket.write_all(&packet[..packet_size])?;
+
+        let mut buf = [0; 2];
+        socket.read_exact(&mut buf)?;
+        if buf[0] != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid response version",
+            ));
+        }
+        if buf[1] != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "password authentication failed",
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Returns the proxy-side address of the connection between the proxy and
+    /// target server.
+    pub fn proxy_addr(&self) -> &TargetAddr {
+        &self.proxy_addr
+    }
+
+    /// Returns a shared reference to the inner `TcpStream`.
+    pub fn get_ref(&self) -> &TcpStream {
+        &self.socket
+    }
+
+    /// Returns a mutable reference to the inner `TcpStream`.
+    pub fn get_mut(&mut self) -> &mut TcpStream {
+        &mut self.socket
+    }
+
+    /// Consumes the `Socks5Stream`, returning the inner `TcpStream`.
+    pub fn into_inner(self) -> TcpStream {
+        self.socket
+    }
+}
+
+impl Read for Socks5Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.socket.read(buf)
+    }
+}
+
+impl<'a> Read for &'a Socks5Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (&self.socket).read(buf)
+    }
+}
+
+impl Write for Socks5Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.socket.flush()
+    }
+}
+
+impl<'a> Write for &'a Socks5Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (&self.socket).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (&self.socket).flush()
+    }
+}
+
+/// A SOCKS5 BIND client.
+#[derive(Debug)]
+pub struct Socks5Listener(Socks5Stream);
+
+impl Socks5Listener {
+    /// Initiates a BIND request to the specified proxy.
+    ///
+    /// The proxy will filter incoming connections based on the value of
+    /// `target`.
+    pub fn bind<T, U>(proxy: T, target: U, timeout: Option<Duration>) -> io::Result<Socks5Listener>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        Socks5Stream::connect_raw(2, proxy, target, &Authentication::None, timeout)
+            .map(Socks5Listener)
+    }
+    /// Initiates a BIND request to the specified proxy using given username
+    /// and password.
+    ///
+    /// The proxy will filter incoming connections based on the value of
+    /// `target`.
+    pub fn bind_with_password<T, U>(
+        proxy: T,
+        target: U,
+        username: &str,
+        password: &str,
+        timeout: Option<Duration>,
+    ) -> io::Result<Socks5Listener>
+    where
+        T: ToSocketAddrs,
+        U: ToTargetAddr,
+    {
+        let auth = Authentication::Password { username, password };
+        Socks5Stream::connect_raw(2, proxy, target, &auth, timeout).map(Socks5Listener)
+    }
+
+    /// The address of the proxy-side TCP listener.
+    ///
+    /// This should be forwarded to the remote process, which should open a
+    /// connection to it.
+    pub fn proxy_addr(&self) -> &TargetAddr {
+        &self.0.proxy_addr
+    }
+
+    /// Waits for the remote process to connect to the proxy server.
+    ///
+    /// The value of `proxy_addr` should be forwarded to the remote process
+    /// before this method is called.
+    pub fn accept(mut self) -> io::Result<Socks5Stream> {
+        self.0.proxy_addr = read_response(&mut self.0.socket)?;
+        Ok(self.0)
+    }
+}
+
+/// A SOCKS5 UDP client.
+#[derive(Debug)]
+pub struct Socks5Datagram {
+    socket: UdpSocket,
+    // keeps the session alive
+    stream: Socks5Stream,
+}
+
+impl Socks5Datagram {
+    /// Creates a UDP socket bound to the specified address which will have its
+    /// traffic routed through the specified proxy.
+    pub fn bind<T, U>(proxy: T, addr: U, timeout: Option<Duration>) -> io::Result<Socks5Datagram>
+    where
+        T: ToSocketAddrs,
+        U: ToSocketAddrs,
+    {
+        Self::bind_internal(proxy, addr, &Authentication::None, timeout)
+    }
+    /// Creates a UDP socket bound to the specified address which will have its
+    /// traffic routed through the specified proxy. The given username and password
+    /// is used to authenticate to the SOCKS proxy.
+    pub fn bind_with_password<T, U>(
+        proxy: T,
+        addr: U,
+        username: &str,
+        password: &str,
+        timeout: Option<Duration>,
+    ) -> io::Result<Socks5Datagram>
+    where
+        T: ToSocketAddrs,
+        U: ToSocketAddrs,
+    {
+        let auth = Authentication::Password { username, password };
+        Self::bind_internal(proxy, addr, &auth, timeout)
+    }
+
+    fn bind_internal<T, U>(
+        proxy: T,
+        addr: U,
+        auth: &Authentication,
+        timeout: Option<Duration>,
+    ) -> io::Result<Socks5Datagram>
+    where
+        T: ToSocketAddrs,
+        U: ToSocketAddrs,
+    {
+        // we don't know what our IP is from the perspective of the proxy, so
+        // don't try to pass `addr` in here.
+        let dst = TargetAddr::Ip(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            0,
+        )));
+        let stream = Socks5Stream::connect_raw(3, proxy, dst, auth, timeout)?;
+
+        let socket = UdpSocket::bind(addr)?;
+        socket.connect(&stream.proxy_addr)?;
+
+        Ok(Socks5Datagram {
+            socket: socket,
+            stream: stream,
+        })
+    }
+
+    /// Like `UdpSocket::send_to`.
+    ///
+    /// # Note
+    ///
+    /// The SOCKS protocol inserts a header at the beginning of the message. The
+    /// header will be 10 bytes for an IPv4 address, 22 bytes for an IPv6
+    /// address, and 7 bytes plus the length of the domain for a domain address.
+    pub fn send_to<A>(&self, buf: &[u8], addr: A) -> io::Result<usize>
+    where
+        A: ToTargetAddr,
+    {
+        let addr = addr.to_target_addr()?;
+
+        let mut header = [0; MAX_ADDR_LEN + 3];
+        // first two bytes are reserved at 0
+        // third byte is the fragment id at 0
+        let len = write_addr(&mut header[3..], &addr)?;
+
+        self.socket.writev([&header[..len + 3], buf])
+    }
+
+    /// Like `UdpSocket::recv_from`.
+    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, TargetAddr)> {
+        let mut header = [0; MAX_ADDR_LEN + 3];
+        let len = self.socket.readv([&mut header, buf])?;
+
+        let overflow = len.saturating_sub(header.len());
+
+        let header_len = cmp::min(header.len(), len);
+        let mut header = &mut &header[..header_len];
+
+        if header.read_u16::<BigEndian>()? != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid reserved bytes",
+            ));
+        }
+        if header.read_u8()? != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid fragment id",
+            ));
+        }
+        let addr = read_addr(&mut header)?;
+
+        unsafe {
+            ptr::copy(
+                buf.as_ptr(),
+                buf.as_mut_ptr().offset(header.len() as isize),
+                overflow,
+            );
+        }
+        buf[..header.len()].copy_from_slice(header);
+
+        Ok((header.len() + overflow, addr))
+    }
+
+    /// Returns the address of the proxy-side UDP socket through which all
+    /// messages will be routed.
+    pub fn proxy_addr(&self) -> &TargetAddr {
+        &self.stream.proxy_addr
+    }
+
+    /// Returns a shared reference to the inner socket.
+    pub fn get_ref(&self) -> &UdpSocket {
+        &self.socket
+    }
+
+    /// Returns a mutable reference to the inner socket.
+    pub fn get_mut(&mut self) -> &mut UdpSocket {
+        &mut self.socket
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::error::Error;
+    use std::io::{Read, Write};
+    use std::net::{TcpStream, ToSocketAddrs, UdpSocket};
+
+    use super::*;
+
+    const SOCKS_PROXY_NO_AUTH_ONLY: &str = "127.0.0.1:1080";
+    const SOCKS_PROXY_PASSWD_ONLY: &str = "127.0.0.1:1081";
+
+    #[test]
+    #[ignore]
+    fn google_no_auth() {
+        let addr = "google.com:80".to_socket_addrs().unwrap().next().unwrap();
+        let socket = Socks5Stream::connect(SOCKS_PROXY_NO_AUTH_ONLY, addr, None).unwrap();
+        google(socket);
+    }
+
+    #[test]
+    #[ignore]
+    fn google_with_password() {
+        let addr = "google.com:80".to_socket_addrs().unwrap().next().unwrap();
+        let socket = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            "testuser",
+            "testpass",
+            None,
+        )
+        .unwrap();
+        google(socket);
+    }
+
+    fn google(mut socket: Socks5Stream) {
+        socket.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+        let mut result = vec![];
+        socket.read_to_end(&mut result).unwrap();
+
+        println!("{}", String::from_utf8_lossy(&result));
+        assert!(result.starts_with(b"HTTP/1.0"));
+        assert!(result.ends_with(b"</HTML>\r\n") || result.ends_with(b"</html>"));
+    }
+
+    #[test]
+    #[ignore]
+    fn google_dns() {
+        let mut socket =
+            Socks5Stream::connect(SOCKS_PROXY_NO_AUTH_ONLY, "google.com:80", None).unwrap();
+
+        socket.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+        let mut result = vec![];
+        socket.read_to_end(&mut result).unwrap();
+
+        println!("{}", String::from_utf8_lossy(&result));
+        assert!(result.starts_with(b"HTTP/1.0"));
+        assert!(result.ends_with(b"</HTML>\r\n") || result.ends_with(b"</html>"));
+    }
+
+    #[test]
+    #[ignore]
+    fn bind_no_auth() {
+        let addr = find_address();
+        let listener = Socks5Listener::bind(SOCKS_PROXY_NO_AUTH_ONLY, addr, None).unwrap();
+        bind(listener);
+    }
+
+    #[test]
+    #[ignore]
+    fn bind_with_password_supported_but_no_auth_used() {
+        let addr = find_address();
+        let listener = Socks5Listener::bind_with_password(
+            SOCKS_PROXY_NO_AUTH_ONLY,
+            addr,
+            "unused_and_invalid_username",
+            "unused_and_invalid_password",
+            None,
+        )
+        .unwrap();
+        bind(listener);
+    }
+
+    #[test]
+    #[ignore]
+    fn bind_with_password() {
+        let addr = find_address();
+        let listener = Socks5Listener::bind_with_password(
+            "127.0.0.1:1081",
+            addr,
+            "testuser",
+            "testpass",
+            None,
+        )
+        .unwrap();
+        bind(listener);
+    }
+
+    fn bind(listener: Socks5Listener) {
+        let addr = listener.proxy_addr().clone();
+        let mut end = TcpStream::connect(addr).unwrap();
+        let mut conn = listener.accept().unwrap();
+        conn.write_all(b"hello world").unwrap();
+        drop(conn);
+        let mut result = vec![];
+        end.read_to_end(&mut result).unwrap();
+        assert_eq!(result, b"hello world");
+    }
+
+    // First figure out our local address that we'll be connecting from
+    fn find_address() -> TargetAddr {
+        let socket =
+            Socks5Stream::connect(SOCKS_PROXY_NO_AUTH_ONLY, "google.com:80", None).unwrap();
+        socket.proxy_addr().to_owned()
+    }
+
+    #[test]
+    #[ignore]
+    fn associate_no_auth() {
+        let socks =
+            Socks5Datagram::bind(SOCKS_PROXY_NO_AUTH_ONLY, "127.0.0.1:15410", None).unwrap();
+        associate(socks, "127.0.0.1:15411");
+    }
+
+    #[test]
+    #[ignore]
+    fn associate_with_password() {
+        let socks = Socks5Datagram::bind_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            "127.0.0.1:15414",
+            "testuser",
+            "testpass",
+            None,
+        )
+        .unwrap();
+        associate(socks, "127.0.0.1:15415");
+    }
+
+    fn associate(socks: Socks5Datagram, socket_addr: &str) {
+        let socket = UdpSocket::bind(socket_addr).unwrap();
+
+        socks.send_to(b"hello world!", socket_addr).unwrap();
+        let mut buf = [0; 13];
+        let (len, addr) = socket.recv_from(&mut buf).unwrap();
+        assert_eq!(len, 12);
+        assert_eq!(&buf[..12], b"hello world!");
+
+        socket.send_to(b"hello world!", addr).unwrap();
+
+        let len = socks.recv_from(&mut buf).unwrap().0;
+        assert_eq!(len, 12);
+        assert_eq!(&buf[..12], b"hello world!");
+    }
+
+    #[test]
+    #[ignore]
+    fn associate_long() {
+        let socks =
+            Socks5Datagram::bind(SOCKS_PROXY_NO_AUTH_ONLY, "127.0.0.1:15412", None).unwrap();
+        let socket_addr = "127.0.0.1:15413";
+        let socket = UdpSocket::bind(socket_addr).unwrap();
+
+        let mut msg = vec![];
+        for i in 0..(MAX_ADDR_LEN + 100) {
+            msg.push(i as u8);
+        }
+
+        socks.send_to(&msg, socket_addr).unwrap();
+        let mut buf = vec![0; msg.len() + 1];
+        let (len, addr) = socket.recv_from(&mut buf).unwrap();
+        assert_eq!(len, msg.len());
+        assert_eq!(msg, &buf[..msg.len()]);
+
+        socket.send_to(&msg, addr).unwrap();
+
+        let mut buf = vec![0; msg.len() + 1];
+        let len = socks.recv_from(&mut buf).unwrap().0;
+        assert_eq!(len, msg.len());
+        assert_eq!(msg, &buf[..msg.len()]);
+    }
+
+    #[test]
+    #[ignore]
+    fn incorrect_password() {
+        let addr = "google.com:80".to_socket_addrs().unwrap().next().unwrap();
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            "testuser",
+            "invalid",
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(err.description(), "password authentication failed");
+    }
+
+    #[test]
+    #[ignore]
+    fn auth_method_not_supported() {
+        let addr = "google.com:80".to_socket_addrs().unwrap().next().unwrap();
+        let err = Socks5Stream::connect(SOCKS_PROXY_PASSWD_ONLY, addr, None).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.description(), "no acceptable auth methods");
+    }
+
+    #[test]
+    #[ignore]
+    fn username_and_password_length() {
+        let addr = "google.com:80".to_socket_addrs().unwrap().next().unwrap();
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(1),
+            &string_of_size(1),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(err.description(), "password authentication failed");
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(255),
+            &string_of_size(255),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(err.description(), "password authentication failed");
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(0),
+            &string_of_size(255),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.description(), "invalid username");
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(256),
+            &string_of_size(255),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.description(), "invalid username");
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(255),
+            &string_of_size(0),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.description(), "invalid password");
+
+        let err = Socks5Stream::connect_with_password(
+            SOCKS_PROXY_PASSWD_ONLY,
+            addr,
+            &string_of_size(255),
+            &string_of_size(256),
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.description(), "invalid password");
+    }
+
+    fn string_of_size(size: usize) -> String {
+        (0..size).map(|_| 'x').collect()
+    }
+}

--- a/src/socks/writev.rs
+++ b/src/socks/writev.rs
@@ -1,0 +1,133 @@
+use std::io;
+use std::net::UdpSocket;
+
+pub trait WritevExt {
+    fn writev(&self, bufs: [&[u8]; 2]) -> io::Result<usize>;
+    fn readv(&self, bufs: [&mut [u8]; 2]) -> io::Result<usize>;
+}
+
+#[cfg(unix)]
+mod imp {
+    use libc;
+    use std::os::unix::io::AsRawFd;
+
+    use super::*;
+
+    impl WritevExt for UdpSocket {
+        fn writev(&self, bufs: [&[u8]; 2]) -> io::Result<usize> {
+            unsafe {
+                let iovecs = [
+                    libc::iovec {
+                        iov_base: bufs[0].as_ptr() as *const _ as *mut _,
+                        iov_len: bufs[0].len(),
+                    },
+                    libc::iovec {
+                        iov_base: bufs[1].as_ptr() as *const _ as *mut _,
+                        iov_len: bufs[1].len(),
+                    },
+                ];
+                let r = libc::writev(self.as_raw_fd(), iovecs.as_ptr(), 2);
+                if r < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(r as usize)
+                }
+            }
+        }
+
+        fn readv(&self, bufs: [&mut [u8]; 2]) -> io::Result<usize> {
+            unsafe {
+                let mut iovecs = [
+                    libc::iovec {
+                        iov_base: bufs[0].as_mut_ptr() as *mut _,
+                        iov_len: bufs[0].len(),
+                    },
+                    libc::iovec {
+                        iov_base: bufs[1].as_mut_ptr() as *mut _,
+                        iov_len: bufs[1].len(),
+                    },
+                ];
+                let r = libc::readv(self.as_raw_fd(), iovecs.as_mut_ptr(), 2);
+                if r < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(r as usize)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::os::windows::io::AsRawSocket;
+    use std::ptr;
+    use winapi::shared::minwindef;
+    use winapi::shared::ws2def;
+    use winapi::um::winsock2;
+
+    use super::*;
+
+    impl WritevExt for UdpSocket {
+        fn writev(&self, bufs: [&[u8]; 2]) -> io::Result<usize> {
+            unsafe {
+                let mut wsabufs = [
+                    ws2def::WSABUF {
+                        len: bufs[0].len() as winsock2::u_long,
+                        buf: bufs[0].as_ptr() as *const _ as *mut _,
+                    },
+                    ws2def::WSABUF {
+                        len: bufs[1].len() as winsock2::u_long,
+                        buf: bufs[1].as_ptr() as *const _ as *mut _,
+                    },
+                ];
+                let mut sent = 0;
+                let r = winsock2::WSASend(
+                    self.as_raw_socket() as usize,
+                    wsabufs.as_mut_ptr(),
+                    bufs.len() as minwindef::DWORD,
+                    &mut sent,
+                    0,
+                    ptr::null_mut(),
+                    None,
+                );
+                if r == 0 {
+                    Ok(sent as usize)
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            }
+        }
+
+        fn readv(&self, bufs: [&mut [u8]; 2]) -> io::Result<usize> {
+            unsafe {
+                let mut wsabufs = [
+                    ws2def::WSABUF {
+                        len: bufs[0].len() as winsock2::u_long,
+                        buf: bufs[0].as_mut_ptr() as *mut _,
+                    },
+                    ws2def::WSABUF {
+                        len: bufs[1].len() as winsock2::u_long,
+                        buf: bufs[1].as_mut_ptr() as *mut _,
+                    },
+                ];
+                let mut recved = 0;
+                let mut flags = 0;
+                let r = winsock2::WSARecv(
+                    self.as_raw_socket() as usize,
+                    wsabufs.as_mut_ptr(),
+                    bufs.len() as minwindef::DWORD,
+                    &mut recved,
+                    &mut flags,
+                    ptr::null_mut(),
+                    None,
+                );
+                if r == 0 {
+                    Ok(recved as usize)
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            }
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -296,8 +296,6 @@ pub enum Error {
     AllAttemptsErrored(Vec<Error>),
     /// There was an io error reading the socket, to be shared between threads
     SharedIOError(Arc<std::io::Error>),
-    /// Setting both a proxy and a timeout in `Config` is an error
-    BothSocksAndTimeout,
 
     /// Couldn't take a lock on the reader mutex. This means that there's already another reader
     /// thread running
@@ -350,7 +348,6 @@ impl Display for Error {
             Error::NotSubscribed(_) => write!(f, "Not subscribed to the notifications of an address"),
 
             Error::MissingDomain => f.write_str("Missing domain while it was explicitly asked to validate it"),
-            Error::BothSocksAndTimeout => f.write_str("Setting both a proxy and a timeout in `Config` is an error"),
             Error::CouldntLockReader => f.write_str("Couldn't take a lock on the reader mutex. This means that there's already another reader thread is running"),
             Error::Mpsc => f.write_str("Broken IPC communication channel: the other thread probably has exited"),
         }


### PR DESCRIPTION
To achieve this we have to include a modified socks library, with supports for
timeout

Remove the error `BothSocksAndTimeout` which isn't needed anymore