### PR TITLE
Client: Drop script subscriptions to free lock

### DIFF
--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -819,6 +819,7 @@ impl<T: Read + Write> ElectrumApi for RawClient<T> {
         }
 
         script_notifications.insert(script_hash, VecDeque::new());
+        drop(script_notifications);
 
         let req = Request::new_id(
             self.last_id.fetch_add(1, Ordering::SeqCst),


### PR DESCRIPTION
This fixes a supposed deadlock when the reader thread receives a script subscription notification from the server before it receives a subscribing response. 

I am not 100% sure if this actually fixes a deadlock, but I ran into this in a regtest setup where a bunch of subscriptions were made, while some script notifications could be processed in parallel. My test failed sporadically with the electrum client locking up completely and adding this drop made the tests consistently pass again.