### PR TITLE
Revert "Ignore empty lines"

### DIFF
--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -494,11 +494,7 @@ impl<S: Read + Write> RawClient<S> {
                         }
                         return Err(Error::SharedIOError(error));
                     }
-                    trace!("<== {:?}", raw_resp);
-
-                    if raw_resp.is_empty() {
-                        continue;
-                    }
+                    trace!("<== {}", raw_resp);
 
                     let resp: serde_json::Value = serde_json::from_str(&raw_resp)?;
 


### PR DESCRIPTION
This reverts commit 0e3e6325e65749c0446fbede99d763b98321362d.

This has been causing issues with tests timing out