### PR TITLE
`timeout()` and `socks()` don't return Result

### DIFF
--- a/examples/tor.rs
+++ b/examples/tor.rs
@@ -6,7 +6,7 @@ fn main() {
     // NOTE: This assumes Tor is running localy, with an unauthenticated Socks5 listening at
     // localhost:9050
     let proxy = Socks5Config::new("127.0.0.1:9050");
-    let config = ConfigBuilder::new().socks5(Some(proxy)).unwrap().build();
+    let config = ConfigBuilder::new().socks5(Some(proxy)).build();
 
     let client = Client::from_config("tcp://explorernuoc63nb.onion:110", config.clone()).unwrap();
     let res = client.server_features();

--- a/src/client.rs
+++ b/src/client.rs
@@ -404,10 +404,7 @@ mod tests {
         let now = Instant::now();
         let client = Client::from_config(
             &endpoint,
-            crate::config::ConfigBuilder::new()
-                .timeout(Some(5))
-                .unwrap()
-                .build(),
+            crate::config::ConfigBuilder::new().timeout(Some(5)).build(),
         );
         let elapsed = now.elapsed();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,15 +44,15 @@ impl ConfigBuilder {
 
     /// Set the socks5 config if Some, it accept an `Option` because it's easier for the caller to use
     /// in a method chain
-    pub fn socks5(mut self, socks5_config: Option<Socks5Config>) -> Result<Self, Error> {
+    pub fn socks5(mut self, socks5_config: Option<Socks5Config>) -> Self {
         self.config.socks5 = socks5_config;
-        Ok(self)
+        self
     }
 
     /// Sets the timeout
-    pub fn timeout(mut self, timeout: Option<u8>) -> Result<Self, Error> {
+    pub fn timeout(mut self, timeout: Option<u8>) -> Self {
         self.config.timeout = timeout.map(|t| Duration::from_secs(t as u64));
-        Ok(self)
+        self
     }
 
     /// Sets the retry attempts number


### PR DESCRIPTION
The `Result` was necessary in the past because they couldn't both be set,
this is not true anymore after 7493630ed88af5558b84a1f715890f67cfa4ec24