### PR TITLE
Add `Batch::raw` and improve docs

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -22,6 +22,11 @@ pub struct Batch {
 }
 
 impl Batch {
+    /// Add a raw request to the batch queue
+    pub fn raw(&mut self, method: String, params: Vec<Param>) {
+        self.calls.push((method, params));
+    }
+
     /// Add one `blockchain.scripthash.listunspent` request to the batch queue
     pub fn script_list_unspent(&mut self, script: &Script) {
         let params = vec![Param::String(script.to_electrum_scripthash().to_hex())];

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,11 @@
-use crate::Error;
 use std::time::Duration;
 
+/// Configuration for an electrum client
+///
+/// Refer to [`Client::from_config`] and [`ClientType::from_config`].
+///
+/// [`Client::from_config`]: crate::Client::from_config
+/// [`ClientType::from_config`]: crate::ClientType::from_config
 #[derive(Debug, Clone)]
 pub struct Config {
     /// Proxy socks5 configuration, default None
@@ -98,19 +103,35 @@ impl Socks5Config {
 }
 
 impl Config {
+    /// Get the configuration for `socks5`
+    ///
+    /// Set this with [`ConfigBuilder::socks5`]
     pub fn socks5(&self) -> &Option<Socks5Config> {
         &self.socks5
     }
+
+    /// Get the configuration for `retry`
+    ///
+    /// Set this with [`ConfigBuilder::retry`]
     pub fn retry(&self) -> u8 {
         self.retry
     }
+
+    /// Get the configuration for `timeout`
+    ///
+    /// Set this with [`ConfigBuilder::timeout`]
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
+
+    /// Get the configuration for `validate_domain`
+    ///
+    /// Set this with [`ConfigBuilder::validate_domain`]
     pub fn validate_domain(&self) -> bool {
         self.validate_domain
     }
 
+    /// Convenience method for calling [`ConfigBuilder::new`]
     pub fn builder() -> ConfigBuilder {
         ConfigBuilder::new()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ use serde::{de, Deserialize, Serialize};
 
 static JSONRPC_2_0: &str = "2.0";
 
-pub type Call = (String, Vec<Param>);
+pub(crate) type Call = (String, Vec<Param>);
 
 #[derive(Serialize, Clone)]
 #[serde(untagged)]


### PR DESCRIPTION
Being able to add raw requests to `Batch` makes sense from an API standpoint because we already allow raw non-batched requests. This is also useful when the electrum server API gets an updated version and our client is unable to keep up.

Additional to this, I have improved the documentation and made `Call` private (since `Call` is never used externally).