### PR TITLE
Retry client should return AlreadySubscribed error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ macro_rules! impl_inner_call {
             drop(read_client);
             match res {
                 Ok(val) => return Ok(val),
-                Err(Error::Protocol(_)) => {
+                Err(Error::Protocol(_) | Error::AlreadySubscribed(_)) => {
                     return res;
                 },
                 Err(e) => {


### PR DESCRIPTION
Users may leverage the Error to avoid remembering client-side the subscription status. eg. Always subscribing and calling script_pop in case AlreadySubscribed is returned.