### PR TITLE
Update rustls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { version = "^1.0" }
 
 # Optional dependencies
 openssl = { version = "0.10", optional = true }
-rustls = { version = "0.20", optional = true, features = ["dangerous_configuration"] }
+rustls = { version = "0.21", optional = true, features = ["dangerous_configuration"] }
 webpki = { version = "0.22", optional = true }
 webpki-roots = { version = "0.22", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum-client"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/MagicalBitcoin/rust-electrum-client"


### PR DESCRIPTION
Update the `rustls` dependency to version 0.21 and bump the version of this crate to 0.16 so the change can be released.

I don't know what stage in your release cycle you guys are up to so I put the version bump as a separate patch - can drop it if not needed.

Done to help with https://github.com/bitcoindevkit/rust-esplora-client/pull/51