### PR TITLE
Remove `webpki` and bump `webpki-roots` to `v0.25`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ serde_json = { version = "^1.0" }
 # Optional dependencies
 openssl = { version = "0.10", optional = true }
 rustls = { version = "0.21", optional = true, features = ["dangerous_configuration"] }
-webpki = { version = "0.22", optional = true }
-webpki-roots = { version = "0.22", optional = true }
+webpki-roots = { version = "0.25", optional = true }
 
 byteorder = { version = "1.0", optional = true }
 
@@ -42,5 +41,5 @@ default = ["proxy", "use-rustls"]
 minimal = []
 debug-calls = []
 proxy = ["byteorder", "winapi", "libc"]
-use-rustls = ["webpki", "webpki-roots", "rustls"]
+use-rustls = ["webpki-roots", "rustls"]
 use-openssl = ["openssl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@ extern crate serde;
 extern crate serde_json;
 
 #[cfg(any(feature = "use-rustls", feature = "default"))]
-extern crate webpki;
-#[cfg(any(feature = "use-rustls", feature = "default"))]
 extern crate webpki_roots;
 
 #[cfg(any(feature = "default", feature = "proxy"))]

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -365,7 +365,7 @@ impl RawClient<ElectrumSslStream> {
             socket_addr.domain().ok_or(Error::MissingDomain)?;
 
             let mut store = RootCertStore::empty();
-            store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.into_iter().map(|t| {
+            store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.into_iter().map(|t| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(
                     t.subject,
                     t.spki,


### PR DESCRIPTION
I noticed that `webpki` dependency is no longer maintained and that has a high severity vulnerability. 
This PR remove the `webpki` dependency and bump `webpki-roots` to v0.25