### PR TITLE
Add utility to validate `GetMerkleRes`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod config;
 pub mod raw_client;
 mod stream;
 mod types;
+pub mod utils;
 
 pub use api::ElectrumApi;
 pub use batch::Batch;

--- a/src/types.rs
+++ b/src/types.rs
@@ -161,7 +161,7 @@ where
 }
 
 /// Response to a [`script_get_history`](../client/struct.Client.html#method.script_get_history) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GetHistoryRes {
     /// Confirmation height of the transaction. 0 if unconfirmed, -1 if unconfirmed while some of
     /// its inputs are unconfirmed too.
@@ -173,7 +173,7 @@ pub struct GetHistoryRes {
 }
 
 /// Response to a [`script_list_unspent`](../client/struct.Client.html#method.script_list_unspent) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ListUnspentRes {
     /// Confirmation height of the transaction that created this output.
     pub height: usize,
@@ -186,7 +186,7 @@ pub struct ListUnspentRes {
 }
 
 /// Response to a [`server_features`](../client/struct.Client.html#method.server_features) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ServerFeaturesRes {
     /// Server version reported.
     pub server_version: String,
@@ -204,7 +204,7 @@ pub struct ServerFeaturesRes {
 }
 
 /// Response to a [`server_features`](../client/struct.Client.html#method.server_features) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GetHeadersRes {
     /// Maximum number of headers returned in a single response.
     pub max: usize,
@@ -219,7 +219,7 @@ pub struct GetHeadersRes {
 }
 
 /// Response to a [`script_get_balance`](../client/struct.Client.html#method.script_get_balance) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GetBalanceRes {
     /// Confirmed balance in Satoshis for the address.
     pub confirmed: u64,
@@ -230,7 +230,7 @@ pub struct GetBalanceRes {
 }
 
 /// Response to a [`transaction_get_merkle`](../client/struct.Client.html#method.transaction_get_merkle) request.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GetMerkleRes {
     /// Height of the block that confirmed the transaction
     pub block_height: usize,
@@ -242,7 +242,7 @@ pub struct GetMerkleRes {
 }
 
 /// Notification of a new block header
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct HeaderNotification {
     /// New block height.
     pub height: usize,
@@ -252,7 +252,7 @@ pub struct HeaderNotification {
 }
 
 /// Notification of a new block header with the header encoded as raw bytes
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct RawHeaderNotification {
     /// New block height.
     pub height: usize,
@@ -273,7 +273,7 @@ impl TryFrom<RawHeaderNotification> for HeaderNotification {
 }
 
 /// Notification of the new status of a script
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ScriptNotification {
     /// Address that generated this notification.
     pub scripthash: ScriptHash,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,43 @@
+//! Utilities helping to handle Electrum-related data.
+
+use bitcoin::hash_types::TxMerkleNode;
+use bitcoin::hashes::sha256d::Hash as Sha256d;
+use bitcoin::hashes::Hash;
+use bitcoin::Txid;
+use types::GetMerkleRes;
+
+/// Verifies a Merkle inclusion proof as retrieved via [`transaction_get_merkle`] for a transaction with the
+/// given `txid` and `merkle_root` as included in the [`BlockHeader`].
+///
+/// Returns `true` if the transaction is included in the corresponding block, and `false`
+/// otherwise.
+///
+/// [`transaction_get_merkle`]: crate::ElectrumApi::transaction_get_merkle
+/// [`BlockHeader`]: bitcoin::BlockHeader
+pub fn validate_merkle_proof(
+    txid: &Txid,
+    merkle_root: &TxMerkleNode,
+    merkle_res: &GetMerkleRes,
+) -> bool {
+    let mut index = merkle_res.pos;
+    let mut cur = txid.to_raw_hash();
+    for bytes in &merkle_res.merkle {
+        let mut reversed = [0u8; 32];
+        reversed.copy_from_slice(bytes);
+        reversed.reverse();
+        // unwrap() safety: `reversed` has len 32 so `from_slice` can never fail.
+        let next_hash = Sha256d::from_slice(&reversed).unwrap();
+
+        let (left, right) = if index % 2 == 0 {
+            (cur, next_hash)
+        } else {
+            (next_hash, cur)
+        };
+
+        let data = [&left[..], &right[..]].concat();
+        cur = Sha256d::hash(&data);
+        index /= 2;
+    }
+
+    cur == merkle_root.to_raw_hash()
+}


### PR DESCRIPTION
I recently needed to validate a Merkle inclusion proof as retrieved via `transaction_get_merkle`. 

As I figured it might be useful to other people, too, we add it here as a simple utility method.