### PR TITLE
Bump version to 0.19.0 and add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project can be found here and in each release's git tag and can be viewed with `git tag -ln100 "v*"`.
+
+Contributors do not need to change this file but do need to add changelog details in their PR descriptions. The person making the next release will collect changelog details from included PRs and edit this file prior to each release.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.19.0]
+
+ - Add Batch::raw and improve docs #94
+ - Remove webpki and bump webpki-roots to v0.25 #117
+ - Upgrade rust-bitcoin to v0.31.0 #121
+ - Add utility to validate GetMerkleRes #122
+ - Enforce timeout on initial socks5 proxy connection #125
+
+## [0.18.0]
+
+ - Revert "errors if expecting headers notification but not subscribed" #115
+
+[0.18.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.17.0...0.18.0
+[0.19.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.18.0...v0.19.0
+[Unreleased]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.19.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum-client"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/MagicalBitcoin/rust-electrum-client"


### PR DESCRIPTION
Besides bumping the version I've also added a simple changelog that list the PRs in this (0.19.0) and the prior (0.18.0) release. The main reason for this release is the bump of the rust-bitcoin version to 0.31.0 which is needed to upgrade dependent projects like bdk to also use rust-bitcoin 0.31.0. 