### PR TITLE
ci: add test with MSRV 1.63.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -3,13 +3,17 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-
   test-fmt:
     name: Test
     runs-on: ubuntu-20.04
     env:
       TEST_ELECTRUM_SERVER: electrum.blockstream.info:50001
       #TEST_ELECTRUM_SERVER: bitcoin.aranguren.org:50001
+    strategy:
+      matrix:
+        rust:
+          - stable # STABLE
+          - 1.63.0 # MSRV
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +28,7 @@ jobs:
       - name: Install rustup
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Set default toolchain
-        run: $HOME/.cargo/bin/rustup default stable
+        run: $HOME/.cargo/bin/rustup default ${{ matrix.rust }}
       - name: Set profile
         run: $HOME/.cargo/bin/rustup set profile minimal
       - name: Fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/electrum-client/"
 description = "Bitcoin Electrum client library. Supports plaintext, TLS and Onion servers."
 keywords = ["bitcoin", "electrum"]
 readme = "README.md"
+rust-version = "1.63.0"
 
 # loosely based on https://github.com/evgeniy-scherbina/rust-electrumx-client
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# rust-electrum-client [![Build Status]][GitHub Workflow] [![Latest Version]][crates.io]
+# rust-electrum-client 
+[![Build Status]][GitHub Workflow] [![Latest Version]][crates.io] [![MSRV Badge]][Rust Blog]
 
 [Build Status]: https://github.com/bitcoindevkit/rust-electrum-client/actions/workflows/cont_integration.yml/badge.svg
 [GitHub Workflow]: https://github.com/bitcoindevkit/rust-electrum-client/actions?query=workflow%3ACI
 [Latest Version]: https://img.shields.io/crates/v/electrum-client.svg
 [crates.io]: https://crates.io/crates/electrum-client
+[MSRV Badge]: https://img.shields.io/badge/rustc-1.63.0%2B-lightgrey.svg
+[Rust Blog]: https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html
 
 Bitcoin Electrum client library. Supports plaintext, TLS and Onion servers.


### PR DESCRIPTION
Since the main BDK crates are changing to MSRV 1.63.0 as is LDK the CI for this project should also have an MSRV and test against it in CI.

Also rustc 1.63 is the version shipped with the current debian stable (bookworm): https://packages.debian.org/stable/rust/rustc