### PR TITLE
Upgrade rustls to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = "^1.0" }
 
 # Optional dependencies
 openssl = { version = "0.10", optional = true }
-rustls = { version = "0.21", optional = true, features = ["dangerous_configuration"] }
+rustls = { version = "0.23", optional = true }
 webpki-roots = { version = "0.25", optional = true }
 
 byteorder = { version = "1.0", optional = true }


### PR DESCRIPTION
With rustls 0.23 there is no longer a dependency on ring, allowing easier compilation for various targets.

Not super confident with my updates to `ServerCertVerifier` and `Der` of certificates (is this being tested?), needs review.