### PR TITLE
chore(deps): upgrade `rust-bitcoin` to `0.32.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum-client"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/MagicalBitcoin/rust-electrum-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "^0.4"
-bitcoin = { version = "0.31.0", features = ["serde"] }
+bitcoin = { version = "0.32", features = ["serde"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

partially fixes [#1422](https://github.com/bitcoindevkit/bdk/issues/1422)

### Description

It updates the rust-bitcoin to 0.32.0, the `bitcoin` crate dependency.

_NOTE: The overall BDK update to `0.32.0` still requires and depends on some other crates, please refer to [#1422](https://github.com/bitcoindevkit/bdk/issues/1422)._

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

It's open for any comments.
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Update the `bitcoin` crate dependency to `0.32.0`

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing