### PR TITLE
Remove proxy as optional feature

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Timeout test
         run: cargo test -- --ignored test_local_timeout
       - run: cargo check --verbose --features=use-openssl
-      - run: cargo check --verbose --no-default-features --features=proxy
+      - run: cargo check --verbose --no-default-features
       - run: cargo check --verbose --no-default-features --features=minimal
       - run: cargo check --verbose --no-default-features --features=minimal,debug-calls
-      - run: cargo check --verbose --no-default-features --features=proxy,use-openssl
-      - run: cargo check --verbose --no-default-features --features=proxy,use-rustls
-      - run: cargo check --verbose --no-default-features --features=proxy,use-rustls-ring
+      - run: cargo check --verbose --no-default-features --features=use-openssl
+      - run: cargo check --verbose --no-default-features --features=use-rustls
+      - run: cargo check --verbose --no-default-features --features=use-rustls-ring
 
   fmt:
     name: Rust fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,19 +29,18 @@ openssl = { version = "0.10", optional = true }
 rustls = { version = "0.23", optional = true, default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 
-byteorder = { version = "1.0", optional = true }
+byteorder = { version = "1.0" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2", optional = true }
+libc = { version = "0.2" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version="0.3.9", features=["winsock2"], optional = true }
+winapi = { version="0.3.9", features=["winsock2"] }
 
 [features]
-default = ["proxy", "use-rustls"]
+default = ["use-rustls"]
 minimal = []
 debug-calls = []
-proxy = ["byteorder", "winapi", "libc"]
 use-rustls = ["webpki-roots", "rustls/default"]
 use-rustls-ring = ["webpki-roots", "rustls/ring", "rustls/logging", "rustls/std", "rustls/tls12"]
 use-openssl = ["openssl"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use std::convert::TryFrom;
 /// [`RawClient`](client/struct.RawClient.html) and provides a more user-friendly
 /// constructor that can choose the right backend based on the url prefix.
 ///
-/// **This is available only with the `default` features, or if `proxy` and one ssl implementation are enabled**
+/// **This is available only with the `default` features, or if one ssl implementation are enabled**
 pub enum ClientType {
     #[allow(missing_docs)]
     TCP(RawClient<ElectrumPlaintextStream>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,24 +43,24 @@ extern crate serde_json;
 ))]
 extern crate webpki_roots;
 
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 extern crate byteorder;
 
-#[cfg(all(unix, any(feature = "default", feature = "proxy")))]
+#[cfg(all(unix, feature = "default"))]
 extern crate libc;
-#[cfg(all(windows, any(feature = "default", feature = "proxy")))]
+#[cfg(all(windows, feature = "default"))]
 extern crate winapi;
 
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 pub mod socks;
 
 mod api;
 mod batch;
 
 #[cfg(any(
-    all(feature = "proxy", feature = "use-openssl"),
-    all(feature = "proxy", feature = "use-rustls"),
-    all(feature = "proxy", feature = "use-rustls-ring")
+    feature = "use-openssl",
+    feature = "use-rustls",
+    feature = "use-rustls-ring"
 ))]
 pub mod client;
 
@@ -74,9 +74,9 @@ pub mod utils;
 pub use api::ElectrumApi;
 pub use batch::Batch;
 #[cfg(any(
-    all(feature = "proxy", feature = "use-openssl"),
-    all(feature = "proxy", feature = "use-rustls"),
-    all(feature = "proxy", feature = "use-rustls-ring")
+    feature = "use-openssl",
+    feature = "use-rustls",
+    feature = "use-rustls-ring"
 ))]
 pub use client::*;
 pub use config::{Config, ConfigBuilder, Socks5Config};

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -36,7 +36,7 @@ use rustls::{
     ClientConfig, ClientConnection, RootCertStore, StreamOwned,
 };
 
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 use crate::socks::{Socks5Stream, TargetAddr, ToTargetAddr};
 
 use crate::stream::ClonableStream;
@@ -93,7 +93,7 @@ impl ToSocketAddrsDomain for (&str, u16) {
     }
 }
 
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 impl ToSocketAddrsDomain for TargetAddr {
     fn domain(&self) -> Option<&str> {
         match self {
@@ -398,8 +398,6 @@ impl RawClient<ElectrumSslStream> {
         validate_domain: bool,
         tcp_stream: TcpStream,
     ) -> Result<Self, Error> {
-        use std::convert::TryFrom;
-
         let builder = ClientConfig::builder();
 
         let config = if validate_domain {
@@ -438,10 +436,10 @@ impl RawClient<ElectrumSslStream> {
     }
 }
 
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 /// Transport type used to establish a connection to a server through a socks proxy
 pub type ElectrumProxyStream = Socks5Stream;
-#[cfg(any(feature = "default", feature = "proxy"))]
+#[cfg(feature = "default")]
 impl RawClient<ElectrumProxyStream> {
     /// Creates a new socks client and tries to connect to `target_addr` using `proxy_addr` as a
     /// socks proxy server. The DNS resolution of `target_addr`, if required, is done


### PR DESCRIPTION
Potentially fixes #91.

I wanted to take a stab at this but I'm not sure I really understood why `proxy` was a feature in the first place. Was there a reason to have it turned off that we want to preserve, in which case we might need to address this by changing the feature-gating done on the Client type?

Anyway just opening this to see if it passes the whole CI workflow.