### PR TITLE
ci: pin msrv dep version for rustls

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -28,6 +28,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Pin dependencies for MSRV
+        if: matrix.rust == '1.63.0'
+        run: |
+          cargo update -p rustls --precise "0.23.17"
       - name: Test
         run: cargo test --verbose --all-features
       - name: Setup iptables for the timeout test

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@
 [Rust Blog]: https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html
 
 Bitcoin Electrum client library. Supports plaintext, TLS and Onion servers.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should compile with any combination of features with Rust 1.63.0.
+
+To build with the MSRV you will need to pin dependencies as follows:
+
+```shell
+cargo update -p rustls --precise "0.23.17"
+```
+


### PR DESCRIPTION
I'm not thrilled about having to pin `rustls` to meet our MSRV, but we need to make a new release and can't count on rustls/rustls#2239 being accepted by the `rustls` team.