### PR TITLE
chore: Enforce min `rustls` version to 0.23.19

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Pin dependencies for MSRV
         if: matrix.rust == '1.63.0'
         run: |
-          cargo update -p rustls --precise "0.23.17"
+          cargo update -p rustls --precise "0.23.19"
       - name: Test
         run: cargo test --verbose --all-features
       - name: Setup iptables for the timeout test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1]
+
+ - Enforce min `rustls` version 0.23.19 to support MSRV with fix for RUSTSEC-2024-0399 #158
+
 ## [0.22.0]
 
  - Updates the NoCertificateVerification implementation for the rustls::client::danger::ServerCertVerifier to use the rustls::SignatureScheme from CryptoProvider in use #150
@@ -43,4 +47,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.20.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.19.0...v0.20.0
 [0.21.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.20.0...v0.21.0
 [0.22.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.21.0...v0.22.0
-[Unreleased]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.22.0...HEAD
+[0.22.1]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.22.0...v0.22.1
+[Unreleased]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.22.1...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum-client"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/bitcoindevkit/rust-electrum-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { version = "^1.0" }
 
 # Optional dependencies
 openssl = { version = "0.10", optional = true }
-rustls = { version = "0.23", optional = true, default-features = false }
+rustls = { version = "0.23.19", optional = true, default-features = false }
 webpki-roots = { version = "0.25", optional = true }
 
 byteorder = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ This library should compile with any combination of features with Rust 1.63.0.
 To build with the MSRV you will need to pin dependencies as follows:
 
 ```shell
-cargo update -p rustls --precise "0.23.17"
+cargo update -p rustls --precise "0.23.19"
 ```
 


### PR DESCRIPTION
`rustls` versions 0.23.18 and 0.23.19 contains fix for vulnerability RUSTSEC-2024-0399. However, 0.23.18 bumps MSRV to 1.71. 0.23.19 reverts MSRV back to 1.63.

We enforce min `rustls` version to 0.23.19 to make it easier to compile on MSRV and ensure we include the RUSTSEC-2024-0399 fix.

Note that in CI, I decided to pin `rustls` dependency to 0.23.19 explicitly. This is because in future versions of `rustls`, the MSRV will be changed to 1.71.

Context: https://github.com/rustls/rustls/pull/2244