### PR TITLE
chore(release): bump version to `0.23.1`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -5,7 +5,7 @@ name: CI
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TEST_ELECTRUM_SERVER: electrum.blockstream.info:50001
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.23.1]
+ - Fix batch request to Electrum servers out of order responses #160
+ - Allow types that references to `ElectrumApi` to also implement it #163
+
 ## [0.23.0]
 
  - Raise MSRV to `1.75` and bump `rustls` to `0.23.21` #159
@@ -50,4 +54,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.21.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.20.0...v0.21.0
 [0.22.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.21.0...v0.22.0
 [0.23.0]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.22.0...v0.23.0
-[Unreleased]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.23.0...HEAD
+[0.23.1]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.23.0...v0.23.1
+[Unreleased]: https://github.com/bitcoindevkit/rust-electrum-client/compare/0.23.1...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrum-client"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/bitcoindevkit/rust-electrum-client"


### PR DESCRIPTION
fixes #168 

- updates the CI to run on `ubuntu-latest` GitHub runner, as the previously used `ubuntu-20.04` has been officially deprecated as of 2025-04-15, see: https://github.com/actions/runner-images/issues/11101.
- updates the project version to `0.23.1`.
- updates the `CHANGELOG.md` with changes to latest version.