### PR TITLE
fix(ci): pin `openssl` and `openssl-sys`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -28,6 +28,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Pin dependencies for MSRV
+        if: matrix.rust == '1.75.0'
+        run: |
+          cargo update -p openssl --precise "0.10.78"
+          cargo update -p openssl-sys --precise "0.9.114"
       - name: Test
         run: cargo test --verbose --all-features
 
@@ -62,6 +67,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
+      - name: Pin dependencies for MSRV
+        if: matrix.rust == '1.75.0'
+        run: |
+          cargo update -p openssl --precise "0.10.78"
+          cargo update -p openssl-sys --precise "0.9.114"
       - name: Check features
         run: cargo check --verbose ${{ matrix.features }}
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Bitcoin Electrum client library. Supports plaintext, TLS and Onion servers.
 
 This library should compile with any combination of features with Rust 1.75.0.
 
+To build with the MSRV you will need to pin dependencies by running:
+
+``` bash
+cargo update -p openssl --precise "0.10.78"
+cargo update -p openssl-sys --precise "0.9.114"
+```
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
## Description
It fixes the CI for 1.75.0 MSRV jobs, by pinning the required dependencies.

## Changelog notice
```
### Fixed
- fix(ci): pin `openssl` and `openssl-sys` for MSRV CI.
```