### PR TITLE
fix: handle concurrent rustls cryptoprovider initialization

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           cargo update -p openssl --precise "0.10.78"
           cargo update -p openssl-sys --precise "0.9.114"
+          cargo update -p zeroize --precise "1.8.2"
       - name: Test
         run: cargo test --verbose --all-features
 
@@ -72,6 +73,7 @@ jobs:
         run: |
           cargo update -p openssl --precise "0.10.78"
           cargo update -p openssl-sys --precise "0.9.114"
+          cargo update -p zeroize --precise "1.8.2"
       - name: Check features
         run: cargo check --verbose ${{ matrix.features }}
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To build with the MSRV you will need to pin dependencies by running:
 ``` bash
 cargo update -p openssl --precise "0.10.78"
 cargo update -p openssl-sys --precise "0.9.114"
+cargo update -p zeroize --precise "1.8.2"
 ```
 
 ## License

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -462,20 +462,28 @@ impl RawClient<ElectrumSslStream> {
             rustls::crypto::CryptoProvider::install_default(
                 rustls::crypto::aws_lc_rs::default_provider(),
             )
-            .map_err(|_| {
-                Error::CouldNotCreateConnection(rustls::Error::General(
-                    "Failed to install CryptoProvider".to_string(),
-                ))
+            .or_else(|_| {
+                rustls::crypto::CryptoProvider::get_default()
+                    .map(|_| ())
+                    .ok_or_else(|| {
+                        Error::CouldNotCreateConnection(rustls::Error::General(
+                            "Failed to install CryptoProvider".to_string(),
+                        ))
+                    })
             })?;
 
             #[cfg(feature = "rustls-ring")]
             rustls::crypto::CryptoProvider::install_default(
                 rustls::crypto::ring::default_provider(),
             )
-            .map_err(|_| {
-                Error::CouldNotCreateConnection(rustls::Error::General(
-                    "Failed to install CryptoProvider".to_string(),
-                ))
+            .or_else(|_| {
+                rustls::crypto::CryptoProvider::get_default()
+                    .map(|_| ())
+                    .ok_or_else(|| {
+                        Error::CouldNotCreateConnection(rustls::Error::General(
+                            "Failed to install CryptoProvider".to_string(),
+                        ))
+                    })
             })?;
         }
 


### PR DESCRIPTION
Fixes #216
References https://github.com/bitcoindevkit/bdk-dart/issues/103

When multiple SSL clients are created concurrently more than one caller can observe that no process-default rustls `CryptoProvider` is installed. This keeps the existing install path, but if `install_default()` fails, it re-checks whether a default provider is now present and treats that as success.

I tried to look for broader context/discussion in things like https://github.com/bitcoindevkit/rust-electrum-client/pull/171#issuecomment-3084433632 and https://github.com/bitcoindevkit/rust-electrum-client/pull/171#issuecomment-3089275824. This keeps the existing `get_default()` guard behavior, but also handles the concurrent "first use" case where another caller installs the provider after the initial check.