### PR TITLE
Fix: blockchain.transaction.id_from_pos compatibility with electrs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -174,7 +174,7 @@ where
         &self,
         height: usize,
         tx_pos: usize,
-    ) -> Result<TxidFromPosRes, Error> {
+    ) -> Result<TxidFromPosMerkleRes, Error> {
         (**self).txid_from_pos_with_merkle(height, tx_pos)
     }
 
@@ -444,7 +444,7 @@ pub trait ElectrumApi {
         &self,
         height: usize,
         tx_pos: usize,
-    ) -> Result<TxidFromPosRes, Error>;
+    ) -> Result<TxidFromPosMerkleRes, Error>;
 
     /// Returns the capabilities of the server.
     fn server_features(&self) -> Result<ServerFeaturesRes, Error>;
@@ -689,7 +689,7 @@ mod test {
             &self,
             _: usize,
             _: usize,
-        ) -> Result<super::TxidFromPosRes, super::Error> {
+        ) -> Result<super::TxidFromPosMerkleRes, super::Error> {
             unreachable!()
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -406,7 +406,7 @@ impl ElectrumApi for Client {
         &self,
         height: usize,
         tx_pos: usize,
-    ) -> Result<TxidFromPosRes, Error> {
+    ) -> Result<TxidFromPosMerkleRes, Error> {
         impl_inner_call!(self, txid_from_pos_with_merkle, height, tx_pos)
     }
 

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -1367,7 +1367,13 @@ impl<T: Read + Write> ElectrumApi for RawClient<T> {
     }
 
     fn txid_from_pos(&self, height: usize, tx_pos: usize) -> Result<Txid, Error> {
-        let params = vec![Param::Usize(height), Param::Usize(tx_pos)];
+        // The `merkle` flag is optional per the protocol, but some server implementations (e.g.
+        // `electrs`) reject requests that omit it, so send it explicitly.
+        let params = vec![
+            Param::Usize(height),
+            Param::Usize(tx_pos),
+            Param::Bool(false),
+        ];
         let req = Request::new_id(
             self.last_id.fetch_add(1, Ordering::SeqCst),
             "blockchain.transaction.id_from_pos",
@@ -1375,7 +1381,7 @@ impl<T: Read + Write> ElectrumApi for RawClient<T> {
         );
         let result = self.call(req)?;
 
-        Ok(serde_json::from_value(result)?)
+        Ok(serde_json::from_value::<TxidFromPosRes>(result)?.into())
     }
 
     fn txid_from_pos_with_merkle(

--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -1382,7 +1382,7 @@ impl<T: Read + Write> ElectrumApi for RawClient<T> {
         &self,
         height: usize,
         tx_pos: usize,
-    ) -> Result<TxidFromPosRes, Error> {
+    ) -> Result<TxidFromPosMerkleRes, Error> {
         let params = vec![
             Param::Usize(height),
             Param::Usize(tx_pos),

--- a/src/types.rs
+++ b/src/types.rs
@@ -347,8 +347,11 @@ pub struct GetMerkleRes {
 /// Response to a [`txid_from_pos_with_merkle`](../client/struct.Client.html#method.txid_from_pos_with_merkle)
 /// request.
 #[derive(Clone, Debug, Deserialize)]
-pub struct TxidFromPosRes {
+pub struct TxidFromPosMerkleRes {
     /// Txid of the transaction.
+    ///
+    /// `electrs` before v0.11.1 named this field `tx_id`, which is accepted as an alias.
+    #[serde(alias = "tx_id")]
     pub tx_hash: Txid,
     /// The merkle path of the transaction.
     #[serde(deserialize_with = "from_hex_array")]
@@ -554,6 +557,27 @@ mod tests {
         let script_status_json = serde_json::to_string(&script_status).unwrap();
         let script_status_back = serde_json::from_str(&script_status_json).unwrap();
         assert_eq!(script_status, script_status_back);
+    }
+
+    #[test]
+    fn txid_from_pos_with_merkle_accepts_legacy_electrs_key() {
+        use super::TxidFromPosMerkleRes;
+        use bitcoin::Txid;
+        use std::str::FromStr;
+
+        let expected =
+            Txid::from_str("1f7ff3c407f33eabc8bec7d2cc230948f2249ec8e591bcf6f971ca9366c8788d")
+                .unwrap();
+
+        // The two JSON keys used by electrs versions <0.11.1, and version 0.11.1.
+        for key in ["tx_id", "tx_hash"] {
+            let json = format!(
+                r#"{{"{key}":"1f7ff3c407f33eabc8bec7d2cc230948f2249ec8e591bcf6f971ca9366c8788d","merkle":["a9642263a86519a8b85a4d3297f58265c1e588803f6ef113f23bb889f5f9bc6e"]}}"#
+            );
+            let parsed: TxidFromPosMerkleRes = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.tx_hash, expected, "failed for key {key}");
+            assert_eq!(parsed.merkle.len(), 1);
+        }
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -344,6 +344,31 @@ pub struct GetMerkleRes {
     pub merkle: Vec<[u8; 32]>,
 }
 
+/// Response to a [`txid_from_pos`](../client/struct.Client.html#method.txid_from_pos) request.
+///
+/// The protocol specifies a bare transaction hash string when `merkle` is `false`, but some
+/// server implementations (e.g. `electrs`) reply with a JSON object holding a `tx_hash` field
+/// instead, so both shapes are accepted. `electrs` before v0.11.1 named that field `tx_id`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum TxidFromPosRes {
+    /// A bare transaction hash.
+    Hash(Txid),
+    /// An object holding the transaction hash.
+    Object {
+        #[serde(alias = "tx_id")]
+        tx_hash: Txid,
+    },
+}
+
+impl From<TxidFromPosRes> for Txid {
+    fn from(raw: TxidFromPosRes) -> Self {
+        match raw {
+            TxidFromPosRes::Hash(tx_hash) | TxidFromPosRes::Object { tx_hash } => tx_hash,
+        }
+    }
+}
+
 /// Response to a [`txid_from_pos_with_merkle`](../client/struct.Client.html#method.txid_from_pos_with_merkle)
 /// request.
 #[derive(Clone, Debug, Deserialize)]
@@ -557,6 +582,31 @@ mod tests {
         let script_status_json = serde_json::to_string(&script_status).unwrap();
         let script_status_back = serde_json::from_str(&script_status_json).unwrap();
         assert_eq!(script_status, script_status_back);
+    }
+
+    #[test]
+    fn txid_from_pos_accepts_both_response_shapes() {
+        use super::TxidFromPosRes;
+        use bitcoin::Txid;
+        use std::str::FromStr;
+
+        let expected =
+            Txid::from_str("1f7ff3c407f33eabc8bec7d2cc230948f2249ec8e591bcf6f971ca9366c8788d")
+                .unwrap();
+
+        // The bare hash string specified by the protocol.
+        let spec_shape = r#""1f7ff3c407f33eabc8bec7d2cc230948f2249ec8e591bcf6f971ca9366c8788d""#;
+        let parsed: TxidFromPosRes = serde_json::from_str(spec_shape).unwrap();
+        assert_eq!(Txid::from(parsed), expected);
+
+        // The two JSON keys used by electrs versions <0.11.1, and version 0.11.1.
+        for key in ["tx_id", "tx_hash"] {
+            let json = format!(
+                r#"{{"{key}":"1f7ff3c407f33eabc8bec7d2cc230948f2249ec8e591bcf6f971ca9366c8788d","merkle":["a9642263a86519a8b85a4d3297f58265c1e588803f6ef113f23bb889f5f9bc6e"]}}"#
+            );
+            let parsed: TxidFromPosRes = serde_json::from_str(&json).unwrap();
+            assert_eq!(Txid::from(parsed), expected, "failed for key {key}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
While working on a lightning `GossipVerifier` in ldk-node, I ran into an issue with the Electrum client.

tl;dr electrs diverges from the Electrum protocol a bit, such that the blockchain.transaction.id_from_pos method doesn't work right now. Fixing this is pretty simple.

There are two issues: the 3rd parameter, `merkle`, not being treated as optional, and the return value formatting when `merkle = false`.

To reproduce, you can run the relevant test against an electrs/0.11.1 server found on https://1209k.com/bitcoin-eye/ele.php, (not qtornado, which is ElectrumX):

```bash
TEST_ELECTRUM_SERVER=electrum.tjader.xyz:50002 cargo test raw_client::test::test_txid_from_pos -- --exact

Finished `test` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests src/lib.rs (target/debug/deps/electrum_client-e59677bf712d816c)

running 1 test
test raw_client::test::test_txid_from_pos ... FAILED

failures:

---- raw_client::test::test_txid_from_pos stdout ----

thread 'raw_client::test::test_txid_from_pos' (3145567) panicked at src/raw_client.rs:1965:53:
called `Result::unwrap()` on an `Err` value: Protocol(Object {"code": Number(-32602), "message": String("invalid params")})
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
If the library adds the `merkle = false` parameter, there is still an issue with parsing the response:

```bash
running 1 test
test raw_client::test::test_txid_from_pos ... FAILED

failures:

---- raw_client::test::test_txid_from_pos stdout ----

thread 'raw_client::test::test_txid_from_pos' (3147516) panicked at src/raw_client.rs:1965:53:
called `Result::unwrap()` on an `Err` value: JSON(Error("invalid type: map, expected an ASCII hex string", line: 0, column: 0))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
You can see the electrs behavior here:

https://github.com/romanz/electrs/blob/9cd09afa229df89214f59816e5142f0f58ff6c48/src/electrum.rs#L466

Additionally, the JSON map key was `tx_id` before version 0.11.1:

https://github.com/romanz/electrs/blob/800bebeea4a3ec4ca924b389338b3449c81b28d4/src/electrum.rs#L484

This PR accepts both versions. You can confirm that behavior with a public electrs v0.10.9 server (I didn't get this working with the cargo test runner):

```bash
Terminal 1: `ncat --sh-exec "ncat -k --proxy-type socks5 --proxy 127.0.0.1:9050 4vrz2q62yxlfmcntnotzdjahpqh2joirp2vrcdsayyioxthffimbp2ad.onion 50001 -v" -l 50506 -k`

Terminal 2: `echo '{"jsonrpc": "2.0", "method": "blockchain.transaction.id_from_pos", "params": [932453,139,false], "id": 0}' | netcat 127.0.0.1 50506`

{"id":0,"jsonrpc":"2.0","result":{"tx_id":"8fed750149034b9e03d5143a95aaa52ee54aa231564f6519be754cfacee0cd0d"}}
```
Added tests for the parsing, and the raw_client:

```bash
TEST_ELECTRUM_SERVER=electrum.tjader.xyz:50002 cargo test raw_client::test::test_txid_from_pos -- --exact
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/debug/deps/electrum_client-e59677bf712d816c)

running 1 test
test raw_client::test::test_txid_from_pos ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 63 filtered out; finished in 0.77s
```
Everything is passing locally for me, though that electrum.tjader.xyz server seems finicky. I also tested this branch in my electrum CLI and confirmed it works against both my personal electrs server, and `electrum.blockstream.info`.

Something like https://github.com/testcontainers/testcontainers-rs could be useful for testing against multiple impls if there's no public (reliable) electrs instance.